### PR TITLE
Build a separate image with Java 8 instead of Java 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pem
+packer-output.*

--- a/packer/build.sh
+++ b/packer/build.sh
@@ -44,7 +44,7 @@ ${PACKER_HOME}/packer build $FLAGS \
   base-ubuntu.json | tee ${PACKER_OUTPUT_FILE}
 
 # Parse the Packer output to find the base Ubuntu image's AMI ID
-BASE_AMI_ID=$(awk '/amazon-ebs: AMI:/ {print $3}' ${PACKER_OUTPUT_FILE} | head -n 1)
+BASE_AMI_ID=$(awk '/eu-west-1: ami-/ {print $2}' ${PACKER_OUTPUT_FILE} | head -n 1)
 echo "Extracted AMI ID ${BASE_AMI_ID} from Packer output" 1>&2
 
 # Build the customised Ubuntu images

--- a/packer/resources/ubuntu-java8.sh
+++ b/packer/resources/ubuntu-java8.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# this is run as root
+
+function new_section {
+  echo
+  echo $(date +"%F %T") $1
+  echo "----------------------------------------------------------------------------------------"
+}
+
+set -e
+## Update index and install packages
+new_section "Configuring extra repositories"
+add-apt-repository "deb http://eu-west-1.ec2.archive.ubuntu.com/ubuntu/ utopic universe"
+# sometimes apt-get update doesn't see the changes here, try sleeping for a moment
+sleep 1
+
+new_section "Updating package lists"
+apt-get update
+
+## Install Java 8 packages
+new_section "Installing Java 8"
+apt-get --yes --force-yes install \
+  openjdk-8-jre-headless openjdk-8-jdk
+
+## Uninstall Java 7 packages
+new_section "Uninstalling Java 7"
+apt-get --yes --force-yes install \
+  openjdk-7-jre-headless openjdk-7-jdk

--- a/packer/resources/ubuntu-java8.sh
+++ b/packer/resources/ubuntu-java8.sh
@@ -24,5 +24,5 @@ apt-get --yes --force-yes install \
 
 ## Uninstall Java 7 packages
 new_section "Uninstalling Java 7"
-apt-get --yes --force-yes install \
+apt-get --yes --force-yes remove \
   openjdk-7-jre-headless openjdk-7-jdk

--- a/packer/ubuntu/ubuntu-java8.json
+++ b/packer/ubuntu/ubuntu-java8.json
@@ -1,0 +1,40 @@
+{
+  "variables": {
+    "name": "ubuntu-java8",
+    "build_number": "DEV",
+    "build_name": null,
+    "build_vcs_ref": "",
+    "account_numbers": "",
+    "build_branch": "DEV",
+    "euw1_source_ami": null
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "eu-west-1",
+      "source_ami": "{{user `euw1_source_ami`}}",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "run_tags": {"Stage":"INFRA", "Stack":"packer", "App": "{{user `build_name`}}"},
+      "ami_name": "{{user `name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+      "ami_description": "AMI for {{user `name`}} built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
+      "ami_users": "{{user `account_numbers`}}",
+      "tags": {
+        "Name": "{{user `name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "BuildName": "{{user `build_name`}}",
+        "Build":"{{user `build_number`}}",
+        "Branch":"{{user `build_branch`}}",
+        "VCSRef":"{{user `build_vcs_ref`}}",
+        "SourceAMI":"{{user `euw1_source_ami`}}"
+      }
+    }
+  ],
+
+  "provisioners" : [
+    {
+      "type": "shell",
+      "script": "resources/ubuntu-java8.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
+    }
+  ]
+}


### PR DESCRIPTION
First build the base Ubuntu image, then use that as a source AMI to build one or more customised Ubuntu images.

The base image includes Java 7, and we have one customised image that replaces Java 7 with 8.

Tested locally. Successfully built ami-190e9c6e (base) and ami-530c9e24 (Java 8).

@sihil @guardian/architects review please
