### PR TITLE
Make the script work with local credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ Building locally
 To build locally you will need:
  - A packer installation (set the `PACKER_HOME` environment variable to the
    location of your packer binaries).
- - Amazon access and secret keys in the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`
-   respectively.
+ - Amazon credentials, either
+  - access and secret keys in the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`
+    respectively
+  - keys in the ~/.aws/credentials file with `AWS_DEFAULT_PROFILE` set if
+    required
 
 Run the `build.sh` in the root of the repository. When not running in
 development mode it will step through the process of image creation.
@@ -41,4 +44,3 @@ TODO
 
  - Investigate using packers chroot builder to accelerate the build process
  - Make it create PV AMIs if that's desirable
- - Look at using your AWS credentials from `.aws/credentials` when running locally

--- a/packer/build.sh
+++ b/packer/build.sh
@@ -21,12 +21,10 @@ FLAGS='-color=false'
 BUILD_NAME=${TEAMCITY_PROJECT_NAME}-${TEAMCITY_BUILDCONF_NAME}
 [ -z "${TEAMCITY_BUILDCONF_NAME}" -o -z "${TEAMCITY_PROJECT_NAME}" ] && BUILD_NAME="unknown"
 
-# ensure that we have AWS credentials (configure in TeamCity normally)
-# note that we don't actually use them in the script, the packer command does
-if [ -z "${AWS_ACCESS_KEY}" -o -z "${AWS_SECRET_KEY}" ]
+# Copy AWS_DEFAULT_PROFILE to AWS_PROFILE (see https://github.com/mitchellh/goamz/blob/master/aws/aws.go)
+if [ -n ${AWS_DEFAULT_PROFILE+x} ]
 then
-  echo "AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables must be set" 1>&2
-  exit 1
+  export AWS_PROFILE=${AWS_DEFAULT_PROFILE}
 fi
 
 # Get all the account numbers of our AWS accounts


### PR DESCRIPTION
At the moment you need to manually set AWS_ACCESS_KEY and AWS_SECRET_KEY if you want to run this. Packer already has support for reading the `.aws/credentials` file - so removing the check in the script will make this work. We do also copy the `AWS_DEFAULT_PROFILE` to `AWS_PROFILE` as the latter is checked by packer whilst the former is checked by the aws-cli.
