### PR TITLE
Get the Java 8 package from the vivid repo, not utopic

### DIFF
--- a/packer/resources/install-java8.sh
+++ b/packer/resources/install-java8.sh
@@ -10,7 +10,7 @@ function new_section {
 set -e
 ## Update index and install packages
 new_section "Configuring extra repositories"
-add-apt-repository "deb http://eu-west-1.ec2.archive.ubuntu.com/ubuntu/ utopic universe"
+add-apt-repository "deb http://eu-west-1.ec2.archive.ubuntu.com/ubuntu/ vivid universe"
 # sometimes apt-get update doesn't see the changes here, try sleeping for a moment
 sleep 1
 


### PR DESCRIPTION
So we can get the latest update of Java 8 (currently 8u45)
