### PR TITLE
Add a feature to rewrite the apt sources files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-*.pem
+ec2_*.pem
 packer_bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-ec2_amazon-ebs.pem
+*.pem
 packer_bin/

--- a/packer/resources/features/rewrite-apt-sources/install.sh
+++ b/packer/resources/features/rewrite-apt-sources/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Rewrite all EC2-specific apt sources to point to the canonical servers.
+# This is useful as a temporary workaround when the Ubuntu EC2 mirrors break, which happens occasionally.
+#
+# This script must be run as root
+set -e
+
+echo Rewriting apt sources files to remove references to EC2 mirrors of Ubuntu repos...
+
+shopt -s nullglob
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*
+do
+  echo Rewriting $f
+  sed -i".bak" -r -e 's/(http(s?)):\/\/[a-z0-9-]+\.ec2\.archive\.ubuntu.com/\1:\/\/archive.ubuntu.com/g'
+  echo Done. Backup saved at ${f}.bak
+done
+
+echo
+echo Finished. You will need to run apt update before the changes take effect.

--- a/packer/resources/features/rewrite-apt-sources/install.sh
+++ b/packer/resources/features/rewrite-apt-sources/install.sh
@@ -12,7 +12,7 @@ shopt -s nullglob
 for f in /etc/apt/sources.list /etc/apt/sources.list.d/*
 do
   echo Rewriting $f
-  sed -i".bak" -r -e 's/(http(s?)):\/\/[a-z0-9-]+\.ec2\.archive\.ubuntu.com/\1:\/\/archive.ubuntu.com/g'
+  sed -i".bak" -r -e 's/(http(s?)):\/\/[a-z0-9-]+\.ec2\.archive\.ubuntu.com/\1:\/\/archive.ubuntu.com/g' "$f"
   echo Done. Backup saved at ${f}.bak
 done
 


### PR DESCRIPTION
This feature rewrites all references to Ubuntu's EC2 mirrors (e.g. eu-west-1.ec2.archive.ubuntu.com) to point to the canonical repo server (archive.ubuntu.com) instead.

This is designed to be used as a temporary workaround for when the EC2 mirrors break, which happens occasionally.

I've tested it manually by spinning up an EC2 instance using the generated AMI and running `install.sh`.
