### PR TITLE
Add simple script for creating and mounting encrypted volumes

### DIFF
--- a/packer/resources/features/ebs/README.md
+++ b/packer/resources/features/ebs/README.md
@@ -1,0 +1,10 @@
+EBS encrypted volumes
+=====================
+
+At the time of writing this, cloudformation did not make it easy to attach
+encrypted EBS volumes to instances inside an auto scaling group.
+
+This simple script gets around this by creating and mounting an encrypted
+volume during instance boot time.
+
+For more details please look at the help at the top of `add-encrypted.sh`.

--- a/packer/resources/features/ebs/add-encrypted.sh
+++ b/packer/resources/features/ebs/add-encrypted.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -e
+
+function HELP {
+>&2 cat << EOF
+
+  Usage: ${0} -d device -s size [ -k key-arn ]
+
+  This script creates and attaches an encrypted EBS volume. This is wrapper
+  around the AWS EC2 CLI and you should see the following docs for clarification
+  to expected parameters:
+    http://docs.aws.amazon.com/cli/latest/reference/ec2/create-volume.html
+    http://docs.aws.amazon.com/cli/latest/reference/ec2/attach-volume.html
+
+    -d device     The device to make available to the instance (e.g. /dev/sdh).
+
+    -s size       The device size.
+
+    -k key-arn    Specify a customer master key to use when encrypting.
+
+    -t type       Specify a volume type.
+
+    -h            Displays this help message. No further functions are
+                  performed.
+
+EOF
+exit 1
+}
+
+# Process options
+while getopts d:s:k:t:h FLAG; do
+  case $FLAG in
+    d)
+      DEVICE=$OPTARG
+      ;;
+    s)
+      SIZE=$OPTARG
+      ;;
+    k)
+      CMK=$OPTARG
+      ;;
+    t)
+      VOLUME_TYPE=$OPTARG
+      ;;
+    h)  #show help
+      HELP
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${DEVICE}" ]; then
+  echo "Must specify a device"
+  exit 1
+fi
+
+if [ -z "${SIZE}" ]; then
+  echo "Must specify a volume size"
+  exit 1
+fi
+
+OPTIONAL_ARGS=""
+
+if [ -n "${CMK}" ]; then
+  OPTIONAL_ARGS="${OPTIONAL_ARGS} --kms-key-id ${CMK}"
+fi
+
+if [ -n "${VOLUME_TYPE}" ]; then
+  OPTIONAL_ARGS="${OPTIONAL_ARGS} --volume-type ${VOLUME_TYPE}"
+fi
+
+SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+source ${SCRIPTPATH}/../templating/metadata.sh
+
+INSTANCE=$(ec2metadata --instance-id)
+REGION=$(get_region)
+ZONE=$(ec2metadata --availability-zone)
+
+function create_volume {
+  local ret=0
+  local CMD="aws ec2 create-volume --region ${REGION} --availability-zone ${ZONE} --size ${SIZE} --encrypted ${OPTIONAL_ARGS}"
+  >&2 echo "Creating volume: ${CMD}"
+  RESULT=`${CMD}` || ret=$?
+  if [ ${ret} == 0 ]; then
+    (echo "${RESULT}" | jq -r '.VolumeId')
+  else
+    >&2 echo "Error creating volume: ${RESULT}"
+    return 1
+  fi
+}
+
+function ec2_wait {
+  local COMMAND=$1
+  local VOLUME_ID=$2
+  # We sleep for five seconds here to make this quicker in the typical case, the
+  # wait command polls every 15s, but actions are normally a lot quicker
+  >&2 echo "Sleeping for 5 seconds to wait for async action to happen"
+  sleep 5
+
+  local ret=0
+  local CMD="aws ec2 wait ${COMMAND} --region ${REGION} --volume-ids ${VOLUME_ID}"
+  >&2 echo "Waiting for state ${COMMAND}: ${CMD}"
+  RESULT=`${CMD}` || ret=$?
+  if [ ${ret} != 0 ]; then
+    >&2 echo "Error attaching volume: ${RESULT}"
+    return 1
+  fi
+}
+
+function attach_volume {
+  local VOLUME_ID=$1
+  local ret=0
+  local CMD="aws ec2 attach-volume --region ${REGION} --volume-id ${VOLUME_ID} --instance-id ${INSTANCE} --device ${DEVICE}"
+  >&2 echo "Attaching volume: ${CMD}"
+  RESULT=`${CMD}` || ret=$?
+  if [ ${ret} != 0 ]; then
+    >&2 echo "Error attaching volume: ${RESULT}"
+    return 1
+  fi
+}
+
+VOLUME_ID=$(create_volume)
+ec2_wait volume-available ${VOLUME_ID}
+attach_volume ${VOLUME_ID}
+ec2_wait volume-in-use ${VOLUME_ID}

--- a/packer/resources/features/ebs/add-encrypted.sh
+++ b/packer/resources/features/ebs/add-encrypted.sh
@@ -14,6 +14,10 @@ function HELP {
 
     -d device     The device to make available to the instance (e.g. /dev/sdh).
 
+    -m mountpoint The fs mountpoint (will be created if necessary).
+
+    -u user       chown the mountpoint to this user.
+
     -s size       The device size.
 
     -k key-arn    Specify a customer master key to use when encrypting.
@@ -28,10 +32,16 @@ exit 1
 }
 
 # Process options
-while getopts d:s:k:t:h FLAG; do
+while getopts d:m:u:s:k:t:h FLAG; do
   case $FLAG in
     d)
       DEVICE=$OPTARG
+      ;;
+    m)
+      MOUNTPOINT=$OPTARG
+      ;;
+    u)
+      MOUNT_USER=$OPTARG
       ;;
     s)
       SIZE=$OPTARG
@@ -123,3 +133,10 @@ VOLUME_ID=$(create_volume)
 ec2_wait volume-available ${VOLUME_ID}
 attach_volume ${VOLUME_ID}
 ec2_wait volume-in-use ${VOLUME_ID}
+if [ -n "${MOUNTPOINT}" ]; then
+  mkdir -p ${MOUNTPOINT}
+  mount ${DEVICE} ${MOUNTPOINT}
+  if [ -n "${MOUNT_USER}" ]; then
+    chown ${MOUNT_USER} ${MOUNTPOINT}
+  fi
+fi

--- a/packer/resources/features/ebs/example-cfn.json
+++ b/packer/resources/features/ebs/example-cfn.json
@@ -1,0 +1,190 @@
+
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Encrypted EBS Example",
+    "Parameters": {
+        "KeyName": {
+            "Description": "The EC2 Key Pair to allow SSH access to the instances",
+            "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "VpcId": {
+            "Description": "ID of the VPC onto which to launch the application",
+            "Type": "AWS::EC2::VPC::Id"
+        },
+        "VpcSubnets": {
+            "Description": "Subnets to use in VPC",
+            "Type": "List<AWS::EC2::Subnet::Id>"
+        },
+        "MachineImagesAMI": {
+            "Description": "AMI id from the machine-images repo",
+            "Type": "String"
+        },
+        "CustomerMasterKey": {
+            "Description": "The KMS CMK to use to encrypt the EBS volume",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "ServerInstanceProfile": {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Path": "/",
+                "Roles": [
+                    {
+                        "Ref": "Role"
+                    }
+                ]
+            }
+        },
+        "Role": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/"
+            }
+        },
+        "DescribeEC2Policy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName": "DescribeEC2Policy",
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "EC2:Describe*",
+                                "elasticloadbalancing:Describe*"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": "*"
+                        },
+                        {
+                            "Action": ["cloudformation:DescribeStacks"],
+                            "Effect": "Allow",
+                            "Resource": {
+                                "Ref": "AWS::StackId"
+                            }
+                        }
+                    ]
+                },
+                "Roles": [{"Ref": "Role"}]
+            }
+        },
+        "CreateEncryptedVolumePolicy": {
+          "Type": "AWS::IAM::Policy",
+          "Properties": {
+              "PolicyName": "CreateEncryptedVolumePolicy",
+              "PolicyDocument": {
+                  "Statement": [
+                      {
+                          "Action": [
+                              "ec2:CreateVolume",
+                              "ec2:AttachVolume",
+                              "ec2:CreateTags",
+                              "ec2:ModifyInstanceAttribute"
+                          ],
+                          "Effect": "Allow",
+                          "Resource": "*"
+                      },
+                      {
+                          "Action": [
+                              "kms:CreateGrant",
+                              "kms:GenerateDataKeyWithoutPlaintext",
+                              "kms:Decrypt"
+                          ],
+                          "Effect": "Allow",
+                          "Resource": { "Ref": "CustomerMasterKey"}
+                      }
+                  ]
+              },
+              "Roles": [{"Ref": "Role"}]
+          }
+        },
+        "SSHSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Allow SSH access from the office",
+                "VpcId": {"Ref": "VpcId"},
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "22",
+                        "ToPort": "22",
+                        "CidrIp": "10.0.0.0/8"
+                    }
+                ]
+            }
+        },
+        "AutoscalingGroup": {
+            "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "Properties": {
+                "VPCZoneIdentifier": {"Ref": "VpcSubnets"},
+                "LaunchConfigurationName": {
+                    "Ref": "LaunchConfig"
+                },
+                "MinSize": 1,
+                "MaxSize": 2,
+                "DesiredCapacity": 1,
+                "Cooldown": "180",
+                "HealthCheckType": "EC2",
+                "HealthCheckGracePeriod": 300,
+                "Tags": [
+                    {
+                        "Key": "Stack",
+                        "Value": "ebs-encryption",
+                        "PropagateAtLaunch": "true"
+                    },
+                    {
+                        "Key": "App",
+                        "Value": "example",
+                        "PropagateAtLaunch": "true"
+                    }
+                ]
+            }
+        },
+        "LaunchConfig": {
+            "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "ImageId": {
+                    "Ref": "MachineImagesAMI"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "SSHSecurityGroup"
+                    }
+                ],
+                "InstanceType": "m3.medium",
+                "IamInstanceProfile": {
+                    "Ref": "ServerInstanceProfile"
+                },
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "#!/bin/bash -ev\n",
+                                "/opt/features/ebs/add-encrypted.sh -s 80 -d h -m /data -x -k ", { "Ref": "CustomerMasterKey" }, "\n"
+                            ]
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packer/resources/features/templating/metadata.sh
+++ b/packer/resources/features/templating/metadata.sh
@@ -73,14 +73,9 @@ function read_tags {
 }
 
 function read_parameters {
-  local STACK DESC ret
+  local STACK=${1}
+  local DESC ret
   local REGION=$(get_region)
-  if echo "${1}" | grep -q 'tag.aws:cloudformation:stack-id'; then
-    eval "local -A TAG_MAP=${1}"
-    STACK=${TAG_MAP["tag.aws:cloudformation:stack-id"]}
-  else
-    STACK=${1}
-  fi
   if [ -z "${STACK}" ]; then
     empty_aa
     return 0
@@ -126,8 +121,14 @@ function get_metadata {
         ;;
       t)
         tag_subs=$(read_tags)
-        param_subs=$(eval read_parameters ${tag_subs})
-        subs=$(eval merge_maps ${subs} ${tag_subs} ${param_subs})
+        if echo "${tag_subs}" | grep -q 'tag.aws:cloudformation:stack-id'; then
+          eval "local -A TAG_MAP=${1}"
+          STACK=${TAG_MAP["tag.aws:cloudformation:stack-id"]}
+          param_subs=$(eval read_parameters ${STACK})
+          subs=$(eval merge_maps ${subs} ${tag_subs} ${param_subs})
+        else
+          subs=$(eval merge_maps ${subs} ${tag_subs})
+        fi
         ;;
       p)
         param_subs=$(read_parameters $OPTARG)

--- a/packer/resources/ubuntu-trusty.sh
+++ b/packer/resources/ubuntu-trusty.sh
@@ -25,12 +25,16 @@ apt-get update
 ## Install packages
 new_section "Installing required packages"
 apt-get --yes --force-yes install \
-  git wget awscli language-pack-en build-essential python-setuptools \
+  git wget language-pack-en build-essential python-setuptools \
   openjdk-7-jre-headless openjdk-7-jdk cloud-guest-utils jq \
-  ntp unzip
+  ntp unzip python3-pip
+
+## Install AWSCLI tools
+new_section "Installing latest AWSCLI"
+pip3 install awscli
 
 ## Install AWS-CFN tools
-new_section "Installing AWS-CFN tools"
+new_section "Installing latest AWS-CFN tools"
 wget -P /root https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 mkdir -p /root/aws-cfn-bootstrap-latest
 tar xvfz /root/aws-cfn-bootstrap-latest.tar.gz --strip-components=1 -C /root/aws-cfn-bootstrap-latest


### PR DESCRIPTION
This will be used by editorial tools for storing data on encrypted volumes. Note that most use of this should be with a specified customer master key to maximise the control we have over our data.

In order to do this, I've also changed the way the AWS CLI is installed. We now install the latest version using pip (the Ubuntu repo version didn't know about encrypted EBS volumes).

The script is capable of creating, attaching, formatting and mounting an EBS volume. It will also copy the instances tags onto the volume and can optionally specify that the volume should be deleted when the instance is terminated.
