### PR TITLE
Add ES index template to avoid using analysed fields by default

### DIFF
--- a/packer/resources/features/elk-stack/elasticsearch-template.json
+++ b/packer/resources/features/elk-stack/elasticsearch-template.json
@@ -1,0 +1,38 @@
+{
+  "template" : "logstash-*",
+  "settings" : {
+    "index.refresh_interval" : "5s"
+  },
+  "mappings" : {
+    "_default_" : {
+       "_all" : {"enabled" : true, "omit_norms" : true},
+       "dynamic_templates" : [ {
+         "message_field" : {
+           "match" : "message",
+           "match_mapping_type" : "string",
+           "mapping" : {
+             "type" : "string", "index" : "analyzed", "omit_norms" : true
+           }
+         }
+       }, {
+         "string_fields" : {
+           "match" : "*",
+           "match_mapping_type" : "string",
+           "mapping" : {
+             "type" : "string", "index" : "not_analyzed", "omit_norms" : true
+           }
+         }
+       } ],
+       "properties" : {
+         "@version": { "type": "string", "index": "not_analyzed" },
+         "geoip"  : {
+           "type" : "object",
+             "dynamic": true,
+             "properties" : {
+               "location" : { "type" : "geo_point" }
+             }
+         }
+       }
+    }
+  }
+}

--- a/packer/resources/features/elk-stack/install.sh
+++ b/packer/resources/features/elk-stack/install.sh
@@ -41,6 +41,7 @@ EOM
 cp $FEATURE_ROOT/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.template
 
 ## Install logstash config
+cp $FEATURE_ROOT/elasticsearch-template.json /etc/logstash/elasticsearch-template.json
 cp $FEATURE_ROOT/logstash-indexer.conf /etc/logstash/conf.d/logstash-indexer.conf
 
 ## Install logstash plugins
@@ -50,7 +51,7 @@ su - logstash -s /bin/sh -c '/opt/logstash/bin/plugin install logstash-input-kin
 wget https://download.elastic.co/kibana/kibana/kibana-${KIBANA_VERSION}-linux-x64.tar.gz -O /tmp/kibana-${KIBANA_VERSION}-linux-x64.tar.gz
 tar xf /tmp/kibana-${KIBANA_VERSION}-linux-x64.tar.gz -C /opt
 mv /opt/kibana-${KIBANA_VERSION}-linux-x64 /opt/kibana
- 
+
 useradd -M -r -U -s /bin/false -d /opt/kibana kibana
 mkdir /var/log/kibana
 chown kibana:kibana /var/log/kibana

--- a/packer/resources/features/elk-stack/logstash-indexer.conf
+++ b/packer/resources/features/elk-stack/logstash-indexer.conf
@@ -11,5 +11,7 @@ output {
     elasticsearch {
         protocol => "http"
         host     => "localhost"
+        template => "/etc/logstash/elasticsearch-template.json"
+        template_overwrite => true
     }
 }


### PR DESCRIPTION
This changes the default template used for logstash indexes to create only the `message` field as analysed and create everything else as non-analysed. This should help with both indexing and visualisation performance.

This overrides a default template that is embedded in the logstash elasticsearch plugin. See https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/lib/logstash/outputs/elasticsearch/elasticsearch-template.json
