### PR TITLE
Add pre-caching to the gnm-* features

### DIFF
--- a/packer/resources/features/gnm-ca/install.sh
+++ b/packer/resources/features/gnm-ca/install.sh
@@ -6,11 +6,6 @@ set -e
 
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 
-# Make sure ca-certificates-java is installed
-if ! (dpkg -s ca-certificates-java 2> /dev/null > /dev/null); then
-    sudo apt-get install -y ca-certificates-java
-fi
-
 mkdir -p /usr/local/share/ca-certificates/GNM
 cp ${SCRIPTPATH}/*.crt /usr/local/share/ca-certificates/GNM
 

--- a/packer/resources/features/gnm-ca/pre-cache.sh
+++ b/packer/resources/features/gnm-ca/pre-cache.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This script must be run as root
+set -e
+
+# Make sure ca-certificates-java is installed
+if ! (dpkg -s ca-certificates-java 2> /dev/null > /dev/null); then
+    apt-get install -y ca-certificates-java
+fi

--- a/packer/resources/features/gnm-dns/install.sh
+++ b/packer/resources/features/gnm-dns/install.sh
@@ -3,11 +3,6 @@
 # This script must be run as root
 set -e
 
-# Make sure dnsmasq is installed
-if ! (dpkg -s dnsmasq 2> /dev/null > /dev/null); then
-    apt-get install -y dnsmasq
-fi
-
 # Generate the config file
 PROXIES=( "10.252.63.100" "10.253.63.100" )
 DOMAINS=( "guprod.gnl" "dc1.gnm" "dc2.gnm" "dmz.gnl" "gws.gutools.co.uk" \

--- a/packer/resources/features/gnm-dns/pre-cache.sh
+++ b/packer/resources/features/gnm-dns/pre-cache.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This script must be run as root
+set -e
+
+# Make sure dnsmasq is installed
+if ! (dpkg -s dnsmasq 2> /dev/null > /dev/null); then
+    apt-get install -y dnsmasq
+fi


### PR DESCRIPTION
We shouldn't run `apt-get` in `install.sh` because it means we depend on a third party at machine boot time.

/ping @sihil
