### PR TITLE
Add a Kong feature and a new Packer script to build Kong AMIs

### DIFF
--- a/packer/kong.json
+++ b/packer/kong.json
@@ -48,6 +48,11 @@
     },
     {
       "type": "shell",
+      "script": "resources/bump-ulimit.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
+    },
+    {
+      "type": "shell",
       "inline": [
         "/usr/bin/sudo -E /bin/bash -x /opt/features/kong/install.sh"
       ]

--- a/packer/kong.json
+++ b/packer/kong.json
@@ -25,7 +25,7 @@
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",
         "VCSRef":"{{user `build_vcs_ref`}}",
-        "SourceAMI":"{{user `euw1_source_ami`}}"
+        "SourceAMI":"{{user `euw1_vivid_source_ami`}}"
       }
     }
   ],

--- a/packer/kong.json
+++ b/packer/kong.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+    "build_number": "DEV",
+    "build_name": null,
+    "build_vcs_ref": "",
+    "account_numbers": "",
+    "build_branch": "DEV",
+    "euw1_vivid_source_ami": "ami-4aa8ea3d"
+  },
+  "builders": [
+    {
+      "name": "kong",
+      "type": "amazon-ebs",
+      "region": "eu-west-1",
+      "source_ami": "{{user `euw1_vivid_source_ami`}}",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "run_tags": {"Stage":"INFRA", "Stack":"packer", "App": "{{user `build_name`}}"},
+      "ami_name": "kong_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+      "ami_description": "AMI for Kong built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
+      "ami_users": "{{user `account_numbers`}}",
+      "tags": {
+        "Name": "kong_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "BuildName": "{{user `build_name`}}",
+        "Build":"{{user `build_number`}}",
+        "Branch":"{{user `build_branch`}}",
+        "VCSRef":"{{user `build_vcs_ref`}}",
+        "SourceAMI":"{{user `euw1_source_ami`}}"
+      }
+    }
+  ],
+
+  "provisioners" : [
+    {
+      "type": "file",
+      "source": "resources/features",
+      "destination": "/tmp"
+    },
+    {
+      "type": "shell",
+      "script": "resources/ubuntu-vivid.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
+    },
+    {
+      "type": "shell",
+      "script": "resources/pre-cache.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "/usr/bin/sudo -E /bin/bash -x /opt/features/kong/install.sh"
+      ]
+    }
+  ]
+}

--- a/packer/resources/bump-ulimit.sh
+++ b/packer/resources/bump-ulimit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# this is run as root
+
+echo "# Added by machine-images (bump-ulimit.sh in github.com/guardian/machine-images)" >> /etc/security/limits.conf
+echo "*  soft  nofile  16384" >> /etc/security/limits.conf
+echo "*  hard  nofile  16384" >> /etc/security/limits.conf

--- a/packer/resources/features/kong/configure.sh
+++ b/packer/resources/features/kong/configure.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Configuration script for the Kong feature.
+#
+# Given a list of Cassandra hostnames, rewrites kong.yml to use those hosts (on port 9042)
+#
+# This script must be run as root
+set -e
+
+USAGE="Usage: $0 [cassandrahost1 [cassandrahost2 ...]]
+
+Example: $0 1.2.3.4 5.6.7.8
+"
+
+if (( $# > 0 )); then
+  search='        - "localhost:9042"'
+  replacement=''
+  for host in "$@"; do
+    replacement="$replacement        - \"${host}:9042\"\n"
+  done
+
+  echo "Backing up kong.yml to /etc/kong/kong.yml.bak"
+  cp /etc/kong/kong.yml{,.bak}
+
+  echo "Writing Cassandra hostnames to kong.yml"
+  # Use perl because sed doesn't play well with newlines
+  perl -pe "s/${search}/${replacement}/" /etc/kong/kong.yml.bak > /etc/kong/kong.yml
+else
+  echo "Not doing anything because you didn't give me any Cassandra hosts."
+fi

--- a/packer/resources/features/kong/install.sh
+++ b/packer/resources/features/kong/install.sh
@@ -6,7 +6,8 @@
 set -e
 
 echo "Installing Kong's dependencies"
-apt-get -y install netcat lua5.1 openssl libpcre3 dnsmasq
+# jq is not a dependency of Kong but it's useful when looking up Cassandra nodes at startup
+apt-get -y install netcat lua5.1 openssl libpcre3 dnsmasq jq
 
 echo "Waiting 10 seconds to settle down after installing dnsmasq"
 sleep 10

--- a/packer/resources/features/kong/install.sh
+++ b/packer/resources/features/kong/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Downloads the Kong package and installs its dependencies
+#
+# This script must be run as root
+set -e
+
+echo "Installing Kong's dependencies"
+apt-get -y install netcat lua5.1 openssl libpcre3 dnsmasq
+
+echo "Waiting 10 seconds to settle down after installing dnsmasq"
+sleep 10
+
+ubuntu_codename=$(lsb_release -c -s)
+echo "Downloading Kong package for $ubuntu_codename"
+wget -qO /tmp/kong.deb "https://downloadkong.org/${ubuntu_codename}_all.deb"
+
+echo "Installing Kong"
+dpkg -i /tmp/kong.deb
+


### PR DESCRIPTION
This adds [Kong](https://getkong.org/) (an API proxy/management layer) as a feature. There are 2 scripts:
- `install.sh` - installs the Kong debian package and its dependencies
- `configure.sh` - configures Kong, telling it where to find Cassandra

Also adds a new Packer script specifically for building a Kong AMI. This script runs `install.sh` at AMI baking time.

Users should run `configure.sh` at boot time, passing it the hostnames (or IP addresses) of all hosts in the Cassandra cluster. (Kong requires Cassandra, and we assume that a Cassandra cluster is already available).

/cc @sihil
