### PR TITLE
Make sure dnsmasq includes additional configuration

### DIFF
--- a/packer/resources/features/gnm-dns/install.sh
+++ b/packer/resources/features/gnm-dns/install.sh
@@ -8,6 +8,9 @@ if ! (dpkg -s dnsmasq 2> /dev/null > /dev/null); then
     apt-get install -y dnsmasq
 fi
 
+# Make sure /etc/dnsmasq.d is being included
+sed -i '/conf-dir/s/^#//g' /etc/dnsmasq.conf
+
 # Generate the config file
 PROXIES=( "10.252.63.100" "10.253.63.100" )
 DOMAINS=( "guprod.gnl" "dc1.gnm" "dc2.gnm" "dmz.gnl" "gws.gutools.co.uk" \


### PR DESCRIPTION
We're trying to get our servers to resolve some internal Guardian hostnames, but I noticed that placing things in `/etc/dnsmasq.d/gnm.conf` wouldn't work unless the `conf-dir` configuration option is uncommented in `/etc/dnsmasq.conf` (confirmed by running `strace` to see what dnsmasq was up to).

Before:

```
# cat dnsmasq.debug.txt |egrep dnsmasq.d
#
```

No results

After:

```
# cat dnsmasq.debug-after-sed.txt |egrep dnsmasq.d
openat(AT_FDCWD, "/etc/dnsmasq.d", O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC) = 4
stat("/etc/dnsmasq.d/README", {st_mode=S_IFREG|0644, st_size=211, ...}) = 0
stat("/etc/dnsmasq.d/README", {st_mode=S_IFREG|0644, st_size=211, ...}) = 0
open("/etc/dnsmasq.d/README", O_RDONLY) = 5
stat("/etc/dnsmasq.d/gnm.conf", {st_mode=S_IFREG|0644, st_size=952, ...}) = 0
stat("/etc/dnsmasq.d/gnm.conf", {st_mode=S_IFREG|0644, st_size=952, ...}) = 0
open("/etc/dnsmasq.d/gnm.conf", O_RDONLY) = 5
```
