### PR TITLE
Make MongoDB EBS volume size a param

### DIFF
--- a/cloudformation/mongo24.json.template
+++ b/cloudformation/mongo24.json.template
@@ -55,6 +55,11 @@
       "Type": "Number",
       "Default": "200"
     },
+    "DatabaseVolumeSize": {
+      "Description": "Size of EBS volume for MongoDB data files",
+      "Type": "Number",
+      "Default": "100"
+    },
     "InstanceType": {
       "Description": "The instance type for the database nodes (typically smaller for prePROD)",
       "Type": "String",
@@ -414,7 +419,7 @@
                     { "Fn::Join": [ "", ["/opt/features/ssh-keys/install.sh -k ", { "Ref": "SshKeyFileS3Url" }, " -u ubuntu", "\n" ]] }
                   ]
                 },
-                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s 100 -d f -m /var/lib/mongodb -o 'defaults,noatime' -u mongodb -x -t io1 -i ", {"Ref":"IOPS"}, " -k ", { "Ref": "CustomerMasterKey" }] ] }, "\n",
+                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref" : "DatabaseVolumeSize" }, " -d f -m /var/lib/mongodb -o 'defaults,noatime' -u mongodb -x -t io1 -i ", {"Ref":"IOPS"}, " -k ", { "Ref": "CustomerMasterKey" }] ] }, "\n",
                 "/opt/features/mongo24/configure.sh --zone_visibility_mask '", { "Ref": "MemberVisibilityMask" } ,"'\n"
               ]
             ]


### PR DESCRIPTION
Makes it easier to update the stack to spin up instances with larger EBS volumes if needed. Similar to how provisioned IOPS is a parameter already.
