### PR TITLE
Don't run install-from-local inside cron job script (ssh-keys feature)

### DIFF
--- a/packer/resources/features/ssh-keys/initialise-keys-and-cron-job.sh
+++ b/packer/resources/features/ssh-keys/initialise-keys-and-cron-job.sh
@@ -8,7 +8,7 @@ function HELP {
 
   Usage: ${0} -t team-github-name -b github-team-keys [-u ubuntu]
 
-  This script runs install-from-local.sh and sets up a cron job for install.sh to regularly
+  This script runs install.sh to install keys from s3 and sets up a cron job to regularly
   update the installed ssh keys
 
     -u user       [optional] the user to install the SSH keys for. Defaults to ubuntu.
@@ -52,7 +52,6 @@ if [ -z "${SSH_USER}" ]; then
   SSH_USER="ubuntu"
 fi
 
-${DIR}/install-from-local.sh -t ${GITHUB_TEAM_NAME}
 ${DIR}/install.sh -t ${GITHUB_TEAM_NAME} -b ${GITHUB_KEYS_BUCKET}
 echo "*/30 * * * * /opt/features/ssh-keys/install.sh -b ${GITHUB_KEYS_BUCKET} -t ${GITHUB_TEAM_NAME}" > ${DIR}/ssh-keys-cron-job.txt
 echo "Initialising cron job"

--- a/packer/resources/features/ssh-keys/key_functions.sh
+++ b/packer/resources/features/ssh-keys/key_functions.sh
@@ -63,7 +63,7 @@ function install_ssh_key_for_user {
   >&2 echo "Overwriting user's authorized_keys file with downloaded file: ${CMD}"
   RESULT=`${CMD}` || ret=$?
   if [ ${ret} != 0 ]; then
-    >&2 echo "Error overwriting authorized_keys"
+    >&2 echo "Error overwriting authorized_keys. Has the downloaded file already been moved?"
     return 1
   fi
 }


### PR DESCRIPTION
So that it can be optionally called from the boot script in cloudformation. I've added a possible cause of the 'error overwriting authorized keys' issue to an error message as well to help debugging.
