### PR TITLE
More robust logic around remembering succesful backups

### DIFF
--- a/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
+++ b/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
@@ -92,15 +92,15 @@ def download_import_team_keys
   logger.info("Downloading document #{keyring_document_key} from bucket #{@options.keys_bucket}")
   s3 = Aws::S3::Client.new
   s3.get_object({bucket: @options.keys_bucket, key: keyring_document_key}, target: '/tmp/flexbackupkeys.gpg')
-  `gpg --homedir /home/mongo-backup/ --import /tmp/flexbackupkeys.gpg`
+  `gpg --homedir /home/mongo-backup/.gnupg/ --import /tmp/flexbackupkeys.gpg`
 end
 
 def generate_gpg_command(filename)
-  keys = `gpg --homedir /home/mongo-backup/ --list-keys | grep uid`
+  keys = `gpg --homedir /home/mongo-backup/.gnupg/ --list-keys | grep uid`
   key_uid_list = keys.split('\n')
   emails = key_uid_list.map{|uid| uid.split('<')[1].tr('>', '').tr("\n", '')}
   emails_as_args = emails.map{|email| "-r #{email}"}.join(' ')
-  encrypt_command =  "gpg --homedir /home/mongo-backup/ -e #{emails_as_args} --trust-model always -o /backup/#{filename}"
+  encrypt_command =  "gpg --homedir /home/mongo-backup/.gnupg/ -e #{emails_as_args} --trust-model always -o /backup/#{filename}"
   logger.info("GPG command: #{encrypt_command}")
   encrypt_command
 end

--- a/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
+++ b/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
@@ -97,7 +97,7 @@ end
 
 def generate_gpg_command(filename)
   keys = `gpg --homedir /home/mongo-backup/.gnupg/ --list-keys | grep uid`
-  key_uid_list = keys.split('\n')
+  key_uid_list = keys.split("\n")
   emails = key_uid_list.map{|uid| uid.split('<')[1].tr('>', '').tr("\n", '')}
   emails_as_args = emails.map{|email| "-r #{email}"}.join(' ')
   encrypt_command =  "gpg --homedir /home/mongo-backup/.gnupg/ -e #{emails_as_args} --trust-model always -o /backup/#{filename}"

--- a/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
+++ b/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
@@ -125,8 +125,14 @@ def upload_to_s3(file_name)
   logger.info("Uploading #{backup_location} to bucket #{@options.backup_bucket} with key #{key}")
   s3 = Aws::S3::Resource.new
   object = s3.bucket(@options.backup_bucket).object(key)
-  object.upload_file(backup_location)
+  upload_success = object.upload_file(backup_location)
+  if upload_success
+    logger.info('Succesfully uploaded to S3.')
+  else
+    logger.error('Failed to upload backup to S3.')
+  end
   `rm #{backup_location}`
+  upload_success
 end
 
 ## main
@@ -156,8 +162,6 @@ ops_manager = MongoDB::OpsManager.new(MongoDB::OpsManagerAPI.new(replica_set_con
 
 latest_snapshot_id = ops_manager.get_latest_snapshot_id
 if check_if_snapshot_new(latest_snapshot_id)
-  # save the id of the snapshot to disk
-  `echo #{latest_snapshot_id} > /tmp/last_snapshot_downloaded.txt`
   # fetch the snapshot download link
   download_link = ops_manager.get_snapshot_download_link(latest_snapshot_id)
   # download and import keys from s3
@@ -165,8 +169,12 @@ if check_if_snapshot_new(latest_snapshot_id)
   # download backup, encrypting at the same time
   encrypted_backup_name=download_encrypt_backup(download_link)
   # upload backup to s3
-  upload_to_s3(encrypted_backup_name)
-  logger.info('MongoDB: Snapshot backup complete!')
+  upload_success = upload_to_s3(encrypted_backup_name)
+  if upload_success
+    # save the id of the snapshot to disk
+    `echo #{latest_snapshot_id} > /tmp/last_snapshot_downloaded.txt`
+    logger.info('MongoDB: Snapshot backup complete!')
+  end
 else
   logger.info ('Snapshot already backed up. Aborting.')
 end


### PR DESCRIPTION
The snapshot backup script uses the rather crude system of storing the id of the last snapshot backed up in /tmp/last_snapshot_downloaded.txt to prevent the same snapshot being backed up multiple times. 

This PR ensures that the id of the snapshot is only saved if that snapshot has actually been successfully backed up. It also adds some logging around the S3 calls to report if the upload failed. 

It also fixes the way the gpg string is generated - previously if we were encrypting with more than one key it would fail.
