### PR TITLE
Add github team keys bucket access, enable ssh-keys feature

### DIFF
--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -538,8 +538,7 @@
               "\n",
               [
                 "#!/bin/bash -ev",
-                { "Fn::Join": [ "", ["/opt/features/ssh-keys/install-from-local.sh -t ", {"Ref":"GithubTeamName"}, "\n"] ] },
-                { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -b github-team-keys -t ", {"Ref":"GithubTeamName"}, "\n"] ] },
+                { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -l -b github-team-keys -t ", {"Ref":"GithubTeamName"}, " || true\n"] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d f -m /var/lib/mongodb/application -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d g -m /var/lib/mongodb/blockstore -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d h -m /var/lib/mongodb/backup -o 'defaults,noatime' -x -u mongodb-mms -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -539,7 +539,7 @@
               [
                 "#!/bin/bash -ev",
                 { "Fn::Join": [ "", ["/opt/features/ssh-keys/install-from-local.sh -t ", {"Ref":"GithubTeamName"}, "\n"] ] },
-                { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -b github-team-keys -t ", {"Ref":"GithubTeamName"}, "\n"] ] }
+                { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -b github-team-keys -t ", {"Ref":"GithubTeamName"}, "\n"] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d f -m /var/lib/mongodb/application -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d g -m /var/lib/mongodb/blockstore -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d h -m /var/lib/mongodb/backup -o 'defaults,noatime' -x -u mongodb-mms -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -60,7 +60,7 @@
     "GithubTeamName": {
       "Description": "Github team name, used for giving ssh accesss to members of the team.",
       "Type": "String",
-      "Default": ""
+      "Default": "OpsManager-SSHAccess"
     }
   },
   "Resources": {

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -56,6 +56,11 @@
       "Description": "PagerDuty HTTPS end-point to use for alerting",
       "Type": "String",
       "AllowedPattern": "https:\/\/.*"
+    },
+    "GithubTeamName": {
+      "Description": "Github team name, used for giving ssh accesss to members of the team.",
+      "Type": "String",
+      "Default": ""
     }
   },
   "Resources": {
@@ -121,6 +126,27 @@
             "Ref": "ServerRole"
           }
         ]
+      }
+    },
+    "GetTeamKeysPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "GetTeamKeysPolicy",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::github-team-keys/*"]
+            },
+            {
+              "Effect":"Allow",
+              "Action": ["s3:ListBucket"],
+              "Resource":"arn:aws:s3:::github-team-keys"
+            }
+          ]
+        },
+        "Roles": [{"Ref": "ServerRole"}]
       }
     },
     "CreateEncryptedVolumePolicy": {
@@ -512,10 +538,13 @@
               "\n",
               [
                 "#!/bin/bash -ev",
+                { "Fn::Join": [ "", ["/opt/features/ssh-keys/install-from-local.sh -t ", {"Ref":"GithubTeamName"}, "\n"] ] },
+                { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -b github-team-keys -t ", {"Ref":"GithubTeamName"}, "\n"] ] }
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d f -m /var/lib/mongodb/application -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d g -m /var/lib/mongodb/blockstore -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d h -m /var/lib/mongodb/backup -o 'defaults,noatime' -x -u mongodb-mms -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 "/opt/features/mongo-opsmanager/server-configure.sh"
+
               ]
             ]
           }

--- a/packer/elk-stack.json
+++ b/packer/elk-stack.json
@@ -5,7 +5,8 @@
     "build_vcs_ref": "",
     "account_numbers": "",
     "build_branch": "DEV",
-    "euw1_source_ami": "ami-4aa8ea3d"
+    "euw1_source_ami": "ami-4aa8ea3d",
+    "instance_profile": "packer-machine-images"
   },
   "builders": [
     {
@@ -19,6 +20,7 @@
       "ami_name": "elk-stack_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
       "ami_description": "AMI for elk-stack built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
       "ami_users": "{{user `account_numbers`}}",
+      "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "elk-stack_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "BuildName": "{{user `build_name`}}",

--- a/packer/mongo24.json
+++ b/packer/mongo24.json
@@ -5,7 +5,8 @@
     "build_vcs_ref": "",
     "account_numbers": "",
     "build_branch": "DEV",
-    "euw1_source_ami": "ami-9d2f0fea"
+    "euw1_source_ami": "ami-9d2f0fea",
+    "instance_profile": "packer-machine-images"
   },
   "builders": [
     {
@@ -19,6 +20,7 @@
       "ami_name": "mongo24_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
       "ami_description": "AMI for mongo24 built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
       "ami_users": "{{user `account_numbers`}}",
+      "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "mongo24_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "BuildName": "{{user `build_name`}}",
@@ -39,6 +41,7 @@
       "ami_name": "mongo-opsmanager_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
       "ami_description": "AMI for mongo-opsmanager built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
       "ami_users": "{{user `account_numbers`}}",
+      "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "mongo-opsmanager_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "BuildName": "{{user `build_name`}}",
@@ -59,6 +62,7 @@
       "ami_name": "mongo-opsmanager-server_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
       "ami_description": "AMI for mongo-opsmanager-server built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
       "ami_users": "{{user `account_numbers`}}",
+      "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "mongo-opsmanager-server_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "BuildName": "{{user `build_name`}}",

--- a/packer/mongo24.json
+++ b/packer/mongo24.json
@@ -6,7 +6,7 @@
     "account_numbers": "",
     "build_branch": "DEV",
     "euw1_source_ami": "ami-9d2f0fea",
-    "instance_profile": "packer-machine-images"
+    "instance_profile": "PackerUser-PackerRole-19TWMDRWLA2T"
   },
   "builders": [
     {

--- a/packer/mongo24.json
+++ b/packer/mongo24.json
@@ -6,7 +6,7 @@
     "account_numbers": "",
     "build_branch": "DEV",
     "euw1_source_ami": "ami-9d2f0fea",
-    "instance_profile": "PackerUser-PackerRole-19TWMDRWLA2T"
+    "instance_profile": "PackerUser-PackerInstanceProfile-O1WXS2KZ0LV1"
   },
   "builders": [
     {


### PR DESCRIPTION
So that we can set a github team to have access via ssh to the instances. I also added the iam_instance_role property to the packer template which allows keys to be pre-cached when the ami is created.
