### PR TITLE
 Use latest automation agent version for Ops Manager

### DIFF
--- a/packer/resources/features/mongo-opsmanager/agent-configure.sh
+++ b/packer/resources/features/mongo-opsmanager/agent-configure.sh
@@ -10,7 +10,7 @@ service set-readahead start
 OM_URL=$( ${SCRIPTPATH}/scripts/opsmanager_url.rb )
 
 # Download and install automation agent
-PACKAGE=mongodb-mms-automation-agent-manager_2.0.12.1296-1_amd64.deb
+PACKAGE=mongodb-mms-automation-agent-manager_latest_amd64.deb
 pushd /tmp
 curl -OL ${OM_URL}/download/agent/automation/${PACKAGE}
 dpkg -i ${PACKAGE}


### PR DESCRIPTION
The version is currently hardcoded to the version provided by Ops Manager 1.8.1.

When a client tries to download a non-existing package, it is faced with an ASCII reply, instead of the expected Debian package: `{"errorCode":"SERVER_ERROR","message":"Internal server error","version":"1","status":"ERROR"}`

Testing with 1.8.3, it seems like the URL `https://OPSMANAGER_URL/download/agent/automation/mongodb-mms-automation-agent-manager_latest_amd64.deb` always results in the latest supported version of the agent.

This change just makes the `agent-configure.sh` script agnostic to the version of OpsManager.

@sihil @philmcmahon 
