### PR TITLE
Make mongo-opsmanager template generic

### DIFF
--- a/cloudformation/mongo-opsmanager.json
+++ b/cloudformation/mongo-opsmanager.json
@@ -402,14 +402,14 @@
               "\n",
               [
                 "#!/bin/bash -ev",
-                
+
                 { "Fn::If" : [
                     "DoNotRetrieveSshKeysFromS3",
                     "# Not retrieving SSH keys from S3",
                     { "Fn::Join": [ "", ["/opt/features/ssh-keys/install.sh -k ", { "Ref": "SshKeyFileS3Url" }, " -u ubuntu", "\n" ]] }
                   ]
                 },
-                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s 100 -d f -m /var/lib/mongodb -o 'defaults,noatime' -x ", {"Ref":"EBSOptions"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
+                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", {"Ref":"DatabaseVolumeSize"}, " -d f -m /var/lib/mongodb -o 'defaults,noatime' -x ", {"Ref":"EBSOptions"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
 
                 "/opt/features/mongo-opsmanager/agent-configure.sh"
               ]

--- a/cloudformation/mongo-opsmanager.json
+++ b/cloudformation/mongo-opsmanager.json
@@ -1,10 +1,20 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "MongoDB test stack",
+  "Description": "MongoDB replica set nodes",
   "Parameters": {
     "KeyName": {
       "Description": "The EC2 Key Pair to allow SSH access to the instance",
       "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "SshKeyFileS3Url": {
+      "Description": "S3 URL for a list of public SSH keys to use for the default ubuntu user",
+      "Type": "String",
+      "Default": ""
+    },
+    "DatabaseVolumeSize": {
+      "Description": "Size of EBS volume for MongoDB data files (GB)",
+      "Type": "Number",
+      "Default": "100"
     },
     "Stage": {
       "Description": "Environment name",
@@ -15,6 +25,10 @@
         "RELEASE",
         "PROD"
       ]
+    },
+    "Stack": {
+      "Description": "Stack name",
+      "Type": "String"
     },
     "VpcId": {
       "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
@@ -40,7 +54,12 @@
     "IOPS": {
       "Description": "IOPS to provision",
       "Type": "Number",
-      "Default": "200"
+      "Default": "1000"
+    }
+  },
+  "Conditions" : {
+    "DoNotRetrieveSshKeysFromS3" : {
+      "Fn::Equals" : [ {"Ref" : "SshKeyFileS3Url"}, "" ]
     }
   },
   "Resources": {
@@ -140,54 +159,6 @@
         "Roles": [{"Ref": "ServerRole"}]
       }
     },
-    "GetDistributablesPolicy": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyName": "GetDistributablesPolicy",
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Action": [
-                "s3:GetObject"
-              ],
-              "Resource": [
-                "arn:aws:s3:::composer-dist/*"
-              ]
-            }
-          ]
-        },
-        "Roles": [
-          {
-            "Ref": "ServerRole"
-          }
-        ]
-      }
-    },
-    "GetConfigPolicy": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyName": "GetConfigPolicy",
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Action": [
-                "s3:GetObject"
-              ],
-              "Resource": [
-                "arn:aws:s3:::guconf-flexible/*"
-              ]
-            }
-          ]
-        },
-        "Roles": [
-          {
-            "Ref": "ServerRole"
-          }
-        ]
-      }
-    },
     "PushLogsPolicy": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
@@ -230,12 +201,39 @@
                 "dynamodb:UpdateItem"
               ],
               "Resource": [
-                "arn:aws:dynamodb:eu-west-1:743583969668:table/mongo-initialisation",
                 {
                   "Fn::Join": [
                     "",
                     [
-                      "arn:aws:dynamodb:eu-west-1:743583969668:table/mongo.rsconfig.flexible-db-",
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":table/mongo-initialisation"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:dynamodb:",
+                      {
+                        "Ref": "AWS::Region"
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":table/mongo.rsconfig.",
+                      {
+                        "Ref": "Stack"
+                      },
+                      "-db-",
                       {
                         "Ref": "Stage"
                       }
@@ -330,6 +328,25 @@
         "HealthCheckGracePeriod": 300,
         "Tags": [
           {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "Stage"
+                  },
+                  ":",
+                  {
+                    "Ref": "Stack"
+                  },
+                  "-db"
+                ]
+              ]
+            },
+            "PropagateAtLaunch": "true"
+          },
+          {
             "Key": "Stage",
             "Value": {
               "Ref": "Stage"
@@ -338,7 +355,7 @@
           },
           {
             "Key": "Stack",
-            "Value": "flexible",
+            "Value": { "Ref" : "Stack" },
             "PropagateAtLaunch": "true"
           },
           {
@@ -376,7 +393,13 @@
               "\n",
               [
                 "#!/bin/bash -ev",
-                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s 100 -d f -m /var/lib/mongodb -o 'defaults,noatime' -x  -t io1 -i ", {"Ref":"IOPS"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
+                { "Fn::If" : [
+                    "DoNotRetrieveSshKeysFromS3",
+                    "# Not retrieving SSH keys from S3",
+                    { "Fn::Join": [ "", ["/opt/features/ssh-keys/install.sh -k ", { "Ref": "SshKeyFileS3Url" }, " -u ubuntu", "\n" ]] }
+                  ]
+                },
+                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref" : "DatabaseVolumeSize" }, " -d f -m /var/lib/mongodb -o 'defaults,noatime' -x  -t io1 -i ", {"Ref":"IOPS"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
                 "/opt/features/mongo-opsmanager/agent-configure.sh"
               ]
             ]


### PR DESCRIPTION
Just like with `mongo24.json.template`, this removes the account specific references and makes the template usable across AWS accounts.

@philmcmahon @markjamesbutler 
