### PR TITLE
DescribeVolumes permission, role for access to team keys s3 bucket.

### DIFF
--- a/cloudformation/packer.template
+++ b/cloudformation/packer.template
@@ -66,6 +66,20 @@
                                "*"
                            ]
                        },
+                        {
+                           "Sid": "PackerVolumeAccess",
+                           "Action": [
+                               "ec2:AttachVolume",
+                               "ec2:CreateVolume",
+                               "ec2:DeleteVolume",
+                               "ec2:DescribeVolume*",
+                               "ec2:DetachVolume"
+                           ],
+                           "Effect": "Allow",
+                           "Resource": [
+                               "*"
+                           ]
+                        },
                        {
                            "Sid": "PackerKeyPairAccess",
                            "Action": [

--- a/cloudformation/packer.template
+++ b/cloudformation/packer.template
@@ -1,105 +1,105 @@
 {
-   "AWSTemplateFormatVersion": "2010-09-09",
+    "AWSTemplateFormatVersion": "2010-09-09",
 
-   "Description" : "CloudFormation template to create a user for packer",
+    "Description" : "CloudFormation template to create a user for packer",
 
-   "Resources": {
+    "Resources": {
 
-       "packer" : {
-           "Type" : "AWS::IAM::User",
-           "Properties" : {
-               "Path" : "/",
-               "Policies" : [ {
-                   "PolicyName" : "packer",
-                   "PolicyDocument" : {
-                       "Version": "2012-10-17",
-                       "Statement":[{
-                           "Sid": "PackerSecurityGroupAccess",
-                           "Action": [
-                               "ec2:CreateSecurityGroup",
-                               "ec2:DeleteSecurityGroup",
-                               "ec2:DescribeSecurityGroups",
-                               "ec2:AuthorizeSecurityGroupIngress",
-                               "ec2:RevokeSecurityGroupIngress"
-                           ],
-                           "Effect": "Allow",
-                           "Resource": [
-                               "*"
-                           ]
-                       },
-                       {
-                           "Sid": "PackerAMIAccess",
-                           "Action": [
-                               "ec2:*Image*"
-                           ],
-                           "Effect": "Allow",
-                           "Resource": [
-                               "*"
-                           ]
-                       },
-                       {
-                           "Sid": "PackerSnapshotAccess",
-                           "Action": [
-                               "ec2:CreateSnapshot",
-                               "ec2:DeleteSnaphot",
-                               "ec2:DescribeSnapshots"
-                           ],
-                           "Effect": "Allow",
-                           "Resource": [
-                               "*"
-                           ]
-                       },
-                       {
-                           "Sid": "PackerInstanceAccess",
-                           "Action": [
-                               "ec2:RunInstances",
-                               "ec2:StartInstances",
-                               "ec2:StopInstances",
-                               "ec2:RebootInstances",
-                               "ec2:TerminateInstances",
-                               "ec2:DescribeInstances",
-                               "ec2:CreateTags"
-                           ],
-                           "Effect": "Allow",
-                           "Resource": [
-                               "*"
-                           ]
-                       },
-                        {
-                           "Sid": "PackerVolumeAccess",
-                           "Action": [
-                               "ec2:AttachVolume",
-                               "ec2:CreateVolume",
-                               "ec2:DeleteVolume",
-                               "ec2:DescribeVolume*",
-                               "ec2:DetachVolume"
-                           ],
-                           "Effect": "Allow",
-                           "Resource": [
-                               "*"
-                           ]
+        "packer" : {
+            "Type" : "AWS::IAM::User",
+            "Properties" : {
+                "Path" : "/",
+                "Policies" : [ {
+                    "PolicyName" : "packer",
+                    "PolicyDocument" : {
+                        "Version": "2012-10-17",
+                        "Statement":[{
+                            "Sid": "PackerSecurityGroupAccess",
+                            "Action": [
+                                "ec2:CreateSecurityGroup",
+                                "ec2:DeleteSecurityGroup",
+                                "ec2:DescribeSecurityGroups",
+                                "ec2:AuthorizeSecurityGroupIngress",
+                                "ec2:RevokeSecurityGroupIngress"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": [
+                                "*"
+                            ]
                         },
-                       {
-                           "Sid": "PackerKeyPairAccess",
-                           "Action": [
-                               "ec2:CreateKeyPair",
-                               "ec2:DeleteKeyPair",
-                               "ec2:DescribeKeyPairs"
-                           ],
-                           "Effect": "Allow",
-                           "Resource": [
-                               "*"
-                           ]
-                       },
-                       {
-                           "Effect":"Allow",
-                           "Action":"iam:PassRole",
-                           "Resource":{ "Fn::Join": [ "", ["arn:aws:iam::095768028460:role/", {"Ref":"PackerRole"}] ] }
-                       }]
-                   }
-               }]
-           }
-       },
+                            {
+                                "Sid": "PackerAMIAccess",
+                                "Action": [
+                                    "ec2:*Image*"
+                                ],
+                                "Effect": "Allow",
+                                "Resource": [
+                                    "*"
+                                ]
+                            },
+                            {
+                                "Sid": "PackerSnapshotAccess",
+                                "Action": [
+                                    "ec2:CreateSnapshot",
+                                    "ec2:DeleteSnaphot",
+                                    "ec2:DescribeSnapshots"
+                                ],
+                                "Effect": "Allow",
+                                "Resource": [
+                                    "*"
+                                ]
+                            },
+                            {
+                                "Sid": "PackerInstanceAccess",
+                                "Action": [
+                                    "ec2:RunInstances",
+                                    "ec2:StartInstances",
+                                    "ec2:StopInstances",
+                                    "ec2:RebootInstances",
+                                    "ec2:TerminateInstances",
+                                    "ec2:DescribeInstances",
+                                    "ec2:CreateTags"
+                                ],
+                                "Effect": "Allow",
+                                "Resource": [
+                                    "*"
+                                ]
+                            },
+                            {
+                                "Sid": "PackerVolumeAccess",
+                                "Action": [
+                                    "ec2:AttachVolume",
+                                    "ec2:CreateVolume",
+                                    "ec2:DeleteVolume",
+                                    "ec2:DescribeVolume*",
+                                    "ec2:DetachVolume"
+                                ],
+                                "Effect": "Allow",
+                                "Resource": [
+                                    "*"
+                                ]
+                            },
+                            {
+                                "Sid": "PackerKeyPairAccess",
+                                "Action": [
+                                    "ec2:CreateKeyPair",
+                                    "ec2:DeleteKeyPair",
+                                    "ec2:DescribeKeyPairs"
+                                ],
+                                "Effect": "Allow",
+                                "Resource": [
+                                    "*"
+                                ]
+                            },
+                            {
+                                "Effect":"Allow",
+                                "Action":"iam:PassRole",
+                                "Resource":{ "Fn::Join": [ "", ["arn:aws:iam::095768028460:role/", {"Ref":"PackerRole"}] ] }
+                            }]
+                    }
+                }]
+            }
+        },
         "PackerRole" : {
             "Type": "AWS::IAM::Role",
             "Properties": {
@@ -142,6 +142,5 @@
                 } ]
             }
         }
-        }
-   }
+    }
 }

--- a/cloudformation/packer.template
+++ b/cloudformation/packer.template
@@ -58,8 +58,7 @@
                                "ec2:RebootInstances",
                                "ec2:TerminateInstances",
                                "ec2:DescribeInstances",
-                               "ec2:CreateTags",
-                               "ec2:DescribeVolumes"
+                               "ec2:CreateTags"
                            ],
                            "Effect": "Allow",
                            "Resource": [

--- a/cloudformation/packer.template
+++ b/cloudformation/packer.template
@@ -58,7 +58,8 @@
                                "ec2:RebootInstances",
                                "ec2:TerminateInstances",
                                "ec2:DescribeInstances",
-                               "ec2:CreateTags"
+                               "ec2:CreateTags",
+                               "ec2:DescribeVolumes"
                            ],
                            "Effect": "Allow",
                            "Resource": [
@@ -80,11 +81,54 @@
                        {
                            "Effect":"Allow",
                            "Action":"iam:PassRole",
-                           "Resource":"arn:aws:iam::743583969668:role/packer-machine-images"
+                           "Resource":{ "Fn::Join": [ "", ["arn:aws:iam::095768028460:role/", {"Ref":"PackerRole"}] ] }
                        }]
                    }
                }]
            }
-       }
+       },
+        "PackerRole" : {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version" : "2012-10-17",
+                    "Statement": [ {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [ "ec2.amazonaws.com" ]
+                        },
+                        "Action": [ "sts:AssumeRole" ]
+                    } ]
+                },
+                "Path": "/",
+                "Policies": [ {
+                    "PolicyName": "listbucket-getobject-github-team-keys-s3",
+                    "PolicyDocument": {
+                        "Version" : "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:ListBucket"
+                                ],
+                                "Resource": [
+                                    "arn:aws:s3:::github-team-keys"
+                                ]
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:GetObject"
+                                ],
+                                "Resource": [
+                                    "arn:aws:s3:::github-team-keys/*"
+                                ]
+                            }
+                        ]
+                    }
+                } ]
+            }
+        }
+        }
    }
 }


### PR DESCRIPTION
This should deal with an error we're seeing at the end of builds where packer tries to clean up unused volumes. For example:
https://teamcity.gutools.co.uk/viewLog.html?tab=buildLog&buildTypeId=Tools_Machi&buildId=758352#_state=26&focus=9150

It also moves the instance role used to access the team keys bucket into cloudformation rather than being created manually.
