### PR TITLE
Add more general EBS option and parameterise instance type

### DIFF
--- a/cloudformation/mongo-opsmanager.json
+++ b/cloudformation/mongo-opsmanager.json
@@ -37,10 +37,19 @@
       "Description": "The KMS CMK to use to encrypt the EBS volume",
       "Type": "String"
     },
-    "IOPS": {
-      "Description": "IOPS to provision",
-      "Type": "Number",
-      "Default": "200"
+    "EBSOptions": {
+      "Description": "Extra parameters to add-encrypted script",
+      "Type": "String",
+      "Default": "-t io1 -i 1000"
+    },
+    "InstanceType": {
+      "Description": "The instance type for the database nodes (typically smaller for prePROD)",
+      "Type": "String",
+      "AllowedValues": [
+        "m4.large",
+        "m4.xlarge",
+        "r3.xlarge"
+      ]
     }
   },
   "Resources": {
@@ -366,7 +375,7 @@
             "Ref": "ReplicationSecurityGroup"
           }
         ],
-        "InstanceType": "m4.large",
+        "InstanceType": { "Ref": "InstanceType" },
         "IamInstanceProfile": {
           "Ref": "ServerInstanceProfile"
         },
@@ -376,7 +385,7 @@
               "\n",
               [
                 "#!/bin/bash -ev",
-                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s 100 -d f -m /var/lib/mongodb -o 'defaults,noatime' -x  -t io1 -i ", {"Ref":"IOPS"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
+                { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s 100 -d f -m /var/lib/mongodb -o 'defaults,noatime' -x ", {"Ref":"EBSOptions"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
                 "/opt/features/mongo-opsmanager/agent-configure.sh"
               ]
             ]


### PR DESCRIPTION
Provisioned IOPS are only really useful in prod for predictable performance. In dev environments `gp2` is usually better and cheaper than severely constrained IOPS provisioning.

In order to facilitate this I've extracted the options passed to the add-encrypt script as a CFN parameter with an appropriate default.

I've also extracted the instance type config.
