### PR TITLE
Improve error message when replica set is no managed by OpsManager

### DIFF
--- a/packer/resources/features/mongo-opsmanager/scripts/mongodb/ops_manager.rb
+++ b/packer/resources/features/mongo-opsmanager/scripts/mongodb/ops_manager.rb
@@ -100,7 +100,7 @@ module MongoDB
     def find_replica_set(config, name)
       rs = config['replicaSets'].find{|rs| rs['_id'] == name}
       if rs.nil?
-        raise FatalError, "Cannot find replica set #{name} in existing configuration"
+        raise FatalError, "Cannot find replica set #{name} in existing configuration. Make sure replica set is imported for automation in Ops Manager."
       end
       rs
     end


### PR DESCRIPTION
Makes debugging failure of `/opt/features/mongo-opsmanager/agent-configure.sh` a bit easier in case the replica set in the group is not set up to be automated by OpsManager.
