### PR TITLE
Add instance profile.

### DIFF
--- a/cloudformation/packer.template
+++ b/cloudformation/packer.template
@@ -141,6 +141,13 @@
                     }
                 } ]
             }
+        },
+        "PackerInstanceProfile" : {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Path": "/",
+                "Roles": [ {"Ref":"PackerRole"} ]
+            }
         }
     }
 }


### PR DESCRIPTION
When you create an instance role in the console it automatically creates an instance profile with the same name. Not so via cloudformation! This change adds an instance profile. (See docs here http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html)
