### PR TITLE
Aggregate EC2 instance monitoring per ASG

### DIFF
--- a/packer/resources/features/cloudwatch-monitoring/install.sh
+++ b/packer/resources/features/cloudwatch-monitoring/install.sh
@@ -37,7 +37,7 @@ function install_cloudwatch_client() {
 function generate_cloudwatch_cron_job() {
   local SCRIPT_PATH=$1
   local DISK_PATHS=$2
-  local CRON_CMD="${SCRIPT_PATH} --from-cron --mem-util --mem-used --mem-avail --swap-util --swap-used"
+  local CRON_CMD="${SCRIPT_PATH} --from-cron --auto-scaling --mem-util --mem-used --mem-avail --swap-util --swap-used"
   if [ "x${DISK_PATHS}" != "x" ]; then
     CRON_CMD="${CRON_CMD} --disk-space-util --disk-space-used --disk-space-avail"
     for D in $(echo $DISK_PATHS | tr ',' '\n'); do


### PR DESCRIPTION
Turns out it is impossible to create alarms unless there is a single metric matching the criteria. Having individual metrics per EC2 instance won't work.

This change adds the flag `--auto-scaling` "Reports Auto Scaling metrics in addition to instance metrics."
