### PR TITLE
Only send ASG aggregated CloudWatch stats

### DIFF
--- a/packer/resources/features/cloudwatch-monitoring/install.sh
+++ b/packer/resources/features/cloudwatch-monitoring/install.sh
@@ -37,7 +37,7 @@ function install_cloudwatch_client() {
 function generate_cloudwatch_cron_job() {
   local SCRIPT_PATH=$1
   local DISK_PATHS=$2
-  local CRON_CMD="${SCRIPT_PATH} --from-cron --auto-scaling --mem-util --mem-used --mem-avail --swap-util --swap-used"
+  local CRON_CMD="${SCRIPT_PATH} --from-cron --auto-scaling=only --mem-util --mem-used --mem-avail --swap-util --swap-used"
   if [ "x${DISK_PATHS}" != "x" ]; then
     CRON_CMD="${CRON_CMD} --disk-space-util --disk-space-used --disk-space-avail"
     for D in $(echo $DISK_PATHS | tr ',' '\n'); do


### PR DESCRIPTION
Aggregate only on ASG, otherwise the number of metrics becomes too large and the Perl script is not smart enough to send them in batches and the monitoring agent will fail silently with:

`{"__type":"com.amazon.coral.service#InvalidParameterValueException","message":"The collection MetricData must not have a size greater than 20."}`
