### PR TITLE
Add alarming-crontab and PagerDuty script

### DIFF
--- a/packer/resources/features/alarming-crontab/install.sh
+++ b/packer/resources/features/alarming-crontab/install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -e
+set -f
+
+SCRIPTPATH=$( cd $(dirname $0/..) ; pwd -P )
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function HELP {
+>&2 cat << EOF
+
+  Usage: ${0} -u user -d description -c cron-definition
+
+  This script adds a crontab entry for the given user and reports to
+  PagerDuty in case the cronjob fails.
+
+    -u user         the user to install crojob for.
+
+    -d description  description of the cronjob
+
+    -c              the cron definition.
+                    E.g. "* * * * *  command to execute"
+
+    -h              Displays this help message. No further functions are
+                    performed.
+
+EOF
+exit 1
+}
+# Process options
+while getopts u:c:d:h FLAG; do
+  case $FLAG in
+    u)
+      CRONTAB_USER=$OPTARG
+      ;;
+    c)
+      CRON_DEFINITION=$OPTARG
+      ;;
+    d)
+      DESCRIPTION=$OPTARG
+      ;;
+    h)  #show help
+      HELP
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+if [ -z "${CRONTAB_USER}" ]; then
+    echo "Must specify a crontab user"
+    exit 1
+fi
+if [ -z "${CRON_DEFINITION}" ]; then
+    echo "Must specify a cron definition"
+    exit 1
+fi
+if [ -z "${DESCRIPTION}" ]; then
+    echo "Must specify a description"
+    exit 1
+fi
+
+CRONTAB_TMP_FILE="/tmp/crontab-entry.$$"
+crontab -l -u ${CRONTAB_USER} 1> ${CRONTAB_TMP_FILE} 2>/dev/null
+echo "${CRON_DEFINITION} || ${SCRIPTPATH}/pagerduty/alert.sh -d \"${DESCRIPTION}\"" >> ${CRONTAB_TMP_FILE}
+crontab -u ${CRONTAB_USER} ${CRONTAB_TMP_FILE}
+rm ${CRONTAB_TMP_FILE}

--- a/packer/resources/features/pagerduty/alert.sh
+++ b/packer/resources/features/pagerduty/alert.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. $DIR/configuration.sh
+
+function HELP {
+>&2 cat << EOF
+
+  Usage: ${0} -d description
+
+  This script creates a new incident in PagerDuty using a pre-configured
+  PagerDuty API key.
+
+    -d decription the incident description
+
+    -h            Displays this help message. No further functions are
+                  performed.
+
+EOF
+exit 1
+}
+# Process options
+while getopts d:h FLAG; do
+  case $FLAG in
+    d)
+      ALERT_DESCRIPTION=$OPTARG
+      ;;
+    h)  #show help
+      HELP
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+if [ -z "${ALERT_DESCRIPTION}" ]; then
+    echo "Must specify an alert description"
+    exit 1
+fi
+
+function current_ami() {
+  echo $(curl -s --max-time 1 http://169.254.169.254/latest/meta-data/ami-id || echo "Unknown")
+}
+
+function instance_id() {
+  echo $(curl -s --max-time 1 http://169.254.169.254/latest/meta-data/instance-id || echo "Unknown")
+}
+
+function trigger_incident() {
+  local PAGERDUTY_SERVICE_KEY=${1}
+  local DESCRIPTION=${2}
+  local CLIENT=${3}
+  curl --max-time 10 -H "Content-type: application/json" -X POST \
+      -d "{
+        \"service_key\": \"${PAGERDUTY_SERVICE_KEY}\",
+        \"event_type\": \"trigger\",
+        \"description\": \"${DESCRIPTION}\",
+        \"client\": \"${CLIENT}\"
+      }" \
+      "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
+}
+
+function main() {
+  local DESCRIPTION=${1}
+  # Load PagerDuty API key
+  source "${PAGERDUTY_SERVICE_KEY_FILE}"
+  if [ -z "${PAGERDUTY_SERVICE_KEY}" ]; then
+    echo "No PagerDuty API key configured"
+    exit 1
+  fi
+  local CLIENT="$(instance_id) running AMI $(current_ami)"
+  trigger_incident "${PAGERDUTY_SERVICE_KEY}" "${DESCRIPTION}" "${CLIENT}"
+}
+
+main "${ALERT_DESCRIPTION}"

--- a/packer/resources/features/pagerduty/configuration.sh
+++ b/packer/resources/features/pagerduty/configuration.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+export PAGERDUTY_SERVICE_KEY_FILE="/etc/pagerduty.conf"

--- a/packer/resources/features/pagerduty/install.sh
+++ b/packer/resources/features/pagerduty/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. $DIR/configuration.sh
+
+function HELP {
+>&2 cat << EOF
+
+  Usage: ${0} -k PAGERDUTY_SERVICE_KEY
+
+  This script installs a shared PagerDuty API key that can be used
+  by alert.sh to trigger PagerDuty incidents.
+
+    -h            Displays this help message. No further functions are
+                  performed.
+
+EOF
+exit 1
+}
+# Process options
+while getopts k:h FLAG; do
+  case $FLAG in
+    k)
+      PAGERDUTY_SERVICE_KEY=$OPTARG
+      ;;
+    h)  #show help
+      HELP
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+if [ -z "${PAGERDUTY_SERVICE_KEY}" ]; then
+    echo "Must specify a PagerDuty API key"
+    exit 1
+fi
+
+echo "PAGERDUTY_SERVICE_KEY=${PAGERDUTY_SERVICE_KEY}" > ${PAGERDUTY_SERVICE_KEY_FILE}
+if [ $? -gt 0 ]; then
+  echo "Could not write PagerDuty API key to file ${PAGERDUTY_SERVICE_KEY_FILE}"
+  exit 2
+fi
+echo "Wrote PagerDuty API key to file ${PAGERDUTY_SERVICE_KEY_FILE}"


### PR DESCRIPTION
We have a few cronjobs that we cannot allow to fail silently e.g. MongoDB database backups.

This PR adds a set of scripts that can be used to easily create a new cronjob that will trigger an incident in PagerDuty if the command in the cronjob exits with a non-zero status.

The first step is to install a PagerDuty service key:

`/opt/features/pagerduty/install.sh -k PAGERDUTY_SERVICE_KEY`

Other scripts can then trigger an alert directly using:

`/opt/features/pagerduty/alert.sh -d "Alert description"`

Or add a new cronjob that is monitored:

`/opt/features/alarming-crontab/install.sh -u USER -d "My important backup job" -c '* * * * *  command to execute'`

This would result in the following crontab entry:

`* * * * *  command to execute || /opt/features/pagerduty/alert.sh -d "My important backup job"`
