### PR TITLE
Refactor to use security groups rather than IP ranges

### DIFF
--- a/cloudformation/mongo-opsmanager-backup.template
+++ b/cloudformation/mongo-opsmanager-backup.template
@@ -28,7 +28,7 @@
     "SSHAccessCIDR": {
       "Description": "IP address range allowed to SSH to the backup instances",
       "Type": "String",
-      "Default": "10.0.0.0/8"
+      "Default": "10.249.0.0/16"
     },
     "EBSOptions": {
       "Description": "Extra parameters to add-encrypted script",

--- a/cloudformation/mongo-opsmanager-backup.template
+++ b/cloudformation/mongo-opsmanager-backup.template
@@ -25,6 +25,11 @@
       "Type": "String",
       "Default": ""
     },
+    "SSHAccessCIDR": {
+      "Description": "IP address range allowed to SSH to the backup instances",
+      "Type": "String",
+      "Default": "10.0.0.0/8"
+    },
     "EBSOptions": {
       "Description": "Extra parameters to add-encrypted script",
       "Type": "String",
@@ -346,7 +351,7 @@
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": "10.0.0.0/8"
+            "CidrIp": { "Ref": "SSHAccessCIDR" }
           }
         ]
       }

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -67,6 +67,24 @@
       "AllowedPattern": "https:\/\/.*"
     }
   },
+  "Mappings": {
+    "OpsManagerVPCSubnets" : {
+      "Private1A": {
+        "CIDR": "10.248.53.0/26"
+      },
+      "Private1B": {
+        "CIDR": "10.248.53.64/26"
+      },
+      "Private1C": {
+        "CIDR": "10.248.53.128/26"
+      }
+    },
+    "GNMNetworks": {
+      "Office": {
+        "CIDR": "10.249.0.0/16"
+      }
+    }
+  },
   "Resources": {
     "ServerInstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
@@ -293,7 +311,19 @@
             "IpProtocol": "tcp",
             "FromPort": "8080",
             "ToPort": "8081",
-            "SourceSecurityGroupId": { "Ref": "BackupLoadBalancerSecurityGroups" }
+            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1A", "CIDR" ] }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8080",
+            "ToPort": "8081",
+            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1B", "CIDR" ] }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8080",
+            "ToPort": "8081",
+            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1C", "CIDR" ] }
           }
         ]
       }
@@ -309,7 +339,7 @@
             "IpProtocol": "tcp",
             "FromPort": "443",
             "ToPort": "443",
-            "CidrIp": "10.0.0.0/8"
+            "CidrIp": { "Fn::FindInMap": [ "GNMNetworks", "Office", "CIDR" ] }
           }
         ],
         "SecurityGroupEgress": [
@@ -317,7 +347,19 @@
             "IpProtocol": "tcp",
             "FromPort": "8080",
             "ToPort": "8080",
-            "CidrIp": "0.0.0.0/0"
+            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1A", "CIDR" ] }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8080",
+            "ToPort": "8080",
+            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1B", "CIDR" ] }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8080",
+            "ToPort": "8080",
+            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1C", "CIDR" ] }
           }
         ]
       }
@@ -392,9 +434,7 @@
           "HealthyThreshold": "2"
         },
         "Subnets": { "Ref": "PrivateVpcSubnets" },
-        "SecurityGroups": [
-          { "Ref": "BackupLoadBalancerSecurityGroups" }
-        ]
+        "SecurityGroups": { "Ref": "BackupLoadBalancerSecurityGroups" }
       }
     },
     "InsufficientHealthyHostsAlarmBackup": {

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -341,11 +341,11 @@
     "OpsManagerReplicationSecurityGroupIngress": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
-        "GroupId": { "Ref": "ReplicationSecurityGroup" },
+        "GroupId": { "Ref": "OpsManagerReplicationSecurityGroup" },
         "IpProtocol": "tcp",
         "FromPort": "27017",
         "ToPort": "27018",
-        "SourceSecurityGroupId": { "Ref": "ReplicationSecurityGroup" }
+        "SourceSecurityGroupId": { "Ref": "OpsManagerReplicationSecurityGroup" }
       }
     },
 

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -20,6 +20,15 @@
       "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
       "Type": "AWS::EC2::VPC::Id"
     },
+    "SSHAccessCIDR": {
+      "Description": "IP address range allowed to SSH to the OpsManager instances",
+      "Type": "String",
+      "Default": "10.0.0.0/8"
+    },
+    "BackupLoadBalancerSecurityGroups": {
+      "Type": "List<AWS::EC2::SecurityGroup::GroupName>",
+      "Description": "Security groups allowed access the backup API"
+    },
     "PrivateVpcSubnets": {
       "Description": "Subnets to use in VPC for private EC2 instances eg. subnet-abcd1234",
       "Type": "List<AWS::EC2::Subnet::Id>"
@@ -244,7 +253,7 @@
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": "10.0.0.0/8"
+            "CidrIp": { "Ref": "SSHAccessCIDR" }
           }
         ]
       }
@@ -284,7 +293,7 @@
             "IpProtocol": "tcp",
             "FromPort": "8080",
             "ToPort": "8081",
-            "SourceSecurityGroupId": { "Ref": "BackupLoadBalancerSecurityGroup" }
+            "SourceSecurityGroupId": { "Ref": "BackupLoadBalancerSecurityGroups" }
           }
         ]
       }
@@ -300,7 +309,7 @@
             "IpProtocol": "tcp",
             "FromPort": "443",
             "ToPort": "443",
-            "CidrIp": "0.0.0.0/0"
+            "CidrIp": "10.0.0.0/8"
           }
         ],
         "SecurityGroupEgress": [
@@ -362,41 +371,7 @@
         ],
         "Dimensions": [ { "Name": "LoadBalancerName", "Value": { "Ref": "MMSLoadBalancer" } } ]
       }
-    },
-
-    "BackupLoadBalancerSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "VpcId": { "Ref": "VpcId" },
-        "GroupDescription": "Allow access to backup endpoint on internal ELB",
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "8081",
-            "ToPort": "8081",
-            "CidrIp": "10.248.202.0/23"
-          },{
-            "IpProtocol": "tcp",
-            "FromPort": "8081",
-            "ToPort": "8081",
-            "CidrIp": "10.248.204.0/23"
-          },{
-            "IpProtocol": "tcp",
-            "FromPort": "8081",
-            "ToPort": "8081",
-            "CidrIp": "10.248.206.0/23"
-          }
-        ],
-        "SecurityGroupEgress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "8080",
-            "ToPort": "8081",
-            "CidrIp": "0.0.0.0/0"
-          }
-        ]
-      }
-    },
+  },
     "BackupLoadBalancer": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
@@ -418,7 +393,7 @@
         },
         "Subnets": { "Ref": "PrivateVpcSubnets" },
         "SecurityGroups": [
-          { "Ref": "BackupLoadBalancerSecurityGroup" }
+          { "Ref": "BackupLoadBalancerSecurityGroups" }
         ]
       }
     },

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -329,6 +329,26 @@
       }
     },
 
+    "OpsManagerReplicationSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow connections between OpsManager MongoDB instances",
+        "VpcId": {
+          "Ref": "VpcId"
+        }
+      }
+    },
+    "OpsManagerReplicationSecurityGroupIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": { "Ref": "ReplicationSecurityGroup" },
+        "IpProtocol": "tcp",
+        "FromPort": "27017",
+        "ToPort": "27018",
+        "SourceSecurityGroupId": { "Ref": "ReplicationSecurityGroup" }
+      }
+    },
+
     "MMSLoadBalancerSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -515,7 +535,8 @@
         "SecurityGroups": [
           { "Ref": "SSHSecurityGroup" },
           { "Ref": "ReplicationSecurityGroup" },
-          { "Ref": "ServerLoadBalancerSecurityGroup"}
+          { "Ref": "ServerLoadBalancerSecurityGroup" },
+          { "Ref": "OpsManagerReplicationSecurityGroup" }
         ],
         "InstanceType": "r3.xlarge",
         "IamInstanceProfile": {

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -26,7 +26,7 @@
       "Default": "10.249.0.0/16"
     },
     "BackupLoadBalancerSecurityGroups": {
-      "Type": "List<AWS::EC2::SecurityGroup::GroupName>",
+      "Type": "List<AWS::EC2::SecurityGroup::Id>",
       "Description": "Security groups allowed access the backup API"
     },
     "PrivateVpcSubnets": {

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -20,15 +20,6 @@
       "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
       "Type": "AWS::EC2::VPC::Id"
     },
-    "SSHAccessCIDR": {
-      "Description": "IP address range allowed to SSH to the OpsManager instances",
-      "Type": "String",
-      "Default": "10.249.0.0/16"
-    },
-    "BackupLoadBalancerSecurityGroups": {
-      "Type": "List<AWS::EC2::SecurityGroup::Id>",
-      "Description": "Security groups allowed access the backup API"
-    },
     "PrivateVpcSubnets": {
       "Description": "Subnets to use in VPC for private EC2 instances eg. subnet-abcd1234",
       "Type": "List<AWS::EC2::Subnet::Id>"
@@ -65,24 +56,11 @@
       "Description": "PagerDuty HTTPS end-point to use for alerting",
       "Type": "String",
       "AllowedPattern": "https:\/\/.*"
-    }
-  },
-  "Mappings": {
-    "OpsManagerVPCSubnets" : {
-      "Private1A": {
-        "CIDR": "10.248.53.0/26"
-      },
-      "Private1B": {
-        "CIDR": "10.248.53.64/26"
-      },
-      "Private1C": {
-        "CIDR": "10.248.53.128/26"
-      }
     },
-    "GNMNetworks": {
-      "Office": {
-        "CIDR": "10.249.0.0/16"
-      }
+    "GithubTeamName": {
+      "Description": "Github team name, used for giving ssh accesss to members of the team.",
+      "Type": "String",
+      "Default": "OpsManager-SSHAccess"
     }
   },
   "Resources": {
@@ -148,6 +126,27 @@
             "Ref": "ServerRole"
           }
         ]
+      }
+    },
+    "GetTeamKeysPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "GetTeamKeysPolicy",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::github-team-keys/*"]
+            },
+            {
+              "Effect":"Allow",
+              "Action": ["s3:ListBucket"],
+              "Resource":"arn:aws:s3:::github-team-keys"
+            }
+          ]
+        },
+        "Roles": [{"Ref": "ServerRole"}]
       }
     },
     "CreateEncryptedVolumePolicy": {
@@ -271,7 +270,7 @@
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": { "Ref": "SSHAccessCIDR" }
+            "CidrIp": "10.0.0.0/8"
           }
         ]
       }
@@ -311,41 +310,9 @@
             "IpProtocol": "tcp",
             "FromPort": "8080",
             "ToPort": "8081",
-            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1A", "CIDR" ] }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "8080",
-            "ToPort": "8081",
-            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1B", "CIDR" ] }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "8080",
-            "ToPort": "8081",
-            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1C", "CIDR" ] }
+            "SourceSecurityGroupId": { "Ref": "BackupLoadBalancerSecurityGroup" }
           }
         ]
-      }
-    },
-
-    "OpsManagerReplicationSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow connections between OpsManager MongoDB instances",
-        "VpcId": {
-          "Ref": "VpcId"
-        }
-      }
-    },
-    "OpsManagerReplicationSecurityGroupIngress": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": { "Ref": "OpsManagerReplicationSecurityGroup" },
-        "IpProtocol": "tcp",
-        "FromPort": "27017",
-        "ToPort": "27018",
-        "SourceSecurityGroupId": { "Ref": "OpsManagerReplicationSecurityGroup" }
       }
     },
 
@@ -359,7 +326,7 @@
             "IpProtocol": "tcp",
             "FromPort": "443",
             "ToPort": "443",
-            "CidrIp": { "Fn::FindInMap": [ "GNMNetworks", "Office", "CIDR" ] }
+            "CidrIp": "0.0.0.0/0"
           }
         ],
         "SecurityGroupEgress": [
@@ -367,19 +334,7 @@
             "IpProtocol": "tcp",
             "FromPort": "8080",
             "ToPort": "8080",
-            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1A", "CIDR" ] }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "8080",
-            "ToPort": "8080",
-            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1B", "CIDR" ] }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "8080",
-            "ToPort": "8080",
-            "CidrIp": { "Fn::FindInMap": [ "OpsManagerVPCSubnets", "Private1C", "CIDR" ] }
+            "CidrIp": "0.0.0.0/0"
           }
         ]
       }
@@ -433,7 +388,41 @@
         ],
         "Dimensions": [ { "Name": "LoadBalancerName", "Value": { "Ref": "MMSLoadBalancer" } } ]
       }
-  },
+    },
+
+    "BackupLoadBalancerSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "VpcId": { "Ref": "VpcId" },
+        "GroupDescription": "Allow access to backup endpoint on internal ELB",
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8081",
+            "ToPort": "8081",
+            "CidrIp": "10.248.202.0/23"
+          },{
+            "IpProtocol": "tcp",
+            "FromPort": "8081",
+            "ToPort": "8081",
+            "CidrIp": "10.248.204.0/23"
+          },{
+            "IpProtocol": "tcp",
+            "FromPort": "8081",
+            "ToPort": "8081",
+            "CidrIp": "10.248.206.0/23"
+          }
+        ],
+        "SecurityGroupEgress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8080",
+            "ToPort": "8081",
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
     "BackupLoadBalancer": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties": {
@@ -454,7 +443,9 @@
           "HealthyThreshold": "2"
         },
         "Subnets": { "Ref": "PrivateVpcSubnets" },
-        "SecurityGroups": { "Ref": "BackupLoadBalancerSecurityGroups" }
+        "SecurityGroups": [
+          { "Ref": "BackupLoadBalancerSecurityGroup" }
+        ]
       }
     },
     "InsufficientHealthyHostsAlarmBackup": {
@@ -535,8 +526,7 @@
         "SecurityGroups": [
           { "Ref": "SSHSecurityGroup" },
           { "Ref": "ReplicationSecurityGroup" },
-          { "Ref": "ServerLoadBalancerSecurityGroup" },
-          { "Ref": "OpsManagerReplicationSecurityGroup" }
+          { "Ref": "ServerLoadBalancerSecurityGroup"}
         ],
         "InstanceType": "r3.xlarge",
         "IamInstanceProfile": {
@@ -548,10 +538,12 @@
               "\n",
               [
                 "#!/bin/bash -ev",
+                { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -l -b github-team-keys -t ", {"Ref":"GithubTeamName"}, " || true\n"] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d f -m /var/lib/mongodb/application -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d g -m /var/lib/mongodb/blockstore -o 'defaults,noatime' -x -u mongodb -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", { "Ref": "EBSVolumeSize" }, " -d h -m /var/lib/mongodb/backup -o 'defaults,noatime' -x -u mongodb-mms -i ", { "Ref": "IOPS" }, " -t io1 -k ", { "Ref": "CustomerMasterKey" }] ] },
                 "/opt/features/mongo-opsmanager/server-configure.sh"
+
               ]
             ]
           }

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -23,7 +23,7 @@
     "SSHAccessCIDR": {
       "Description": "IP address range allowed to SSH to the OpsManager instances",
       "Type": "String",
-      "Default": "10.0.0.0/8"
+      "Default": "10.249.0.0/16"
     },
     "BackupLoadBalancerSecurityGroups": {
       "Type": "List<AWS::EC2::SecurityGroup::GroupName>",

--- a/cloudformation/mongo-opsmanager.template
+++ b/cloudformation/mongo-opsmanager.template
@@ -11,6 +11,19 @@
       "Type": "String",
       "Default": ""
     },
+    "SSHAccessCIDR": {
+      "Description": "IP address range allowed to SSH to the MongoDB instances",
+      "Type": "String",
+      "Default": "10.0.0.0/8"
+    },
+    "ReplicationSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Description": "Security group allowed to access port 27017 for replication"
+    },
+    "ClientSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Description": "Security group allowed to access port 27017 as clients"
+    },
     "DatabaseVolumeSize": {
       "Description": "Size of EBS volume for MongoDB data files (GB)",
       "Type": "Number",
@@ -365,24 +378,7 @@
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": "10.0.0.0/8"
-          }
-        ]
-      }
-    },
-    "ReplicationSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow connections to mongo DB",
-        "VpcId": {
-          "Ref": "VpcId"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "27017",
-            "ToPort": "27017",
-            "CidrIp": "10.0.0.0/8"
+            "CidrIp": { "Ref": "SSHAccessCIDR"}
           }
         ]
       }
@@ -461,6 +457,9 @@
           },
           {
             "Ref": "ReplicationSecurityGroup"
+          },
+          {
+            "Ref": "ClientSecurityGroup"
           }
         ],
         "InstanceType": { "Ref": "InstanceType" },

--- a/cloudformation/mongo-opsmanager.template
+++ b/cloudformation/mongo-opsmanager.template
@@ -14,7 +14,7 @@
     "SSHAccessCIDR": {
       "Description": "IP address range allowed to SSH to the MongoDB instances",
       "Type": "String",
-      "Default": "10.0.0.0/8"
+      "Default": "10.249.0.0/16"
     },
     "ReplicationSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup::GroupName",

--- a/cloudformation/mongo-opsmanager.template
+++ b/cloudformation/mongo-opsmanager.template
@@ -17,11 +17,11 @@
       "Default": "10.249.0.0/16"
     },
     "ReplicationSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Type": "AWS::EC2::SecurityGroup::Id",
       "Description": "Security group allowed to access port 27017 for replication"
     },
     "ClientSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Type": "AWS::EC2::SecurityGroup::Id",
       "Description": "Security group allowed to access port 27017 as clients"
     },
     "DatabaseVolumeSize": {

--- a/cloudformation/mongo24.template
+++ b/cloudformation/mongo24.template
@@ -24,6 +24,19 @@
       "Description": "Stack name",
       "Type": "String"
     },
+    "SSHAccessCIDR": {
+      "Description": "IP address range allowed to SSH to the MongoDB instances",
+      "Type": "String",
+      "Default": "10.0.0.0/8"
+    },
+    "ReplicationSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Description": "Security group allowed to access port 27017 for replication"
+    },
+    "ClientSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Description": "Security group allowed to access port 27017 as clients"
+    },
     "VpcId": {
       "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
       "Type": "AWS::EC2::VPC::Id"
@@ -374,24 +387,7 @@
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": "10.0.0.0/8"
-          }
-        ]
-      }
-    },
-    "ReplicationSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Allow connections to mongo DB",
-        "VpcId": {
-          "Ref": "VpcId"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "27017",
-            "ToPort": "27017",
-            "CidrIp": "10.0.0.0/8"
+            "CidrIp": { "Ref": "SSHAccessCIDR" }
           }
         ]
       }
@@ -472,6 +468,9 @@
           },
           {
             "Ref": "ReplicationSecurityGroup"
+          },
+          {
+            "Ref": "ClientSecurityGroup"
           }
         ],
         "InstanceType": { "Ref": "InstanceType" },

--- a/cloudformation/mongo24.template
+++ b/cloudformation/mongo24.template
@@ -30,11 +30,11 @@
       "Default": "10.249.0.0/16"
     },
     "ReplicationSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Type": "AWS::EC2::SecurityGroup::Id",
       "Description": "Security group allowed to access port 27017 for replication"
     },
     "ClientSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup::GroupName",
+      "Type": "AWS::EC2::SecurityGroup::Id",
       "Description": "Security group allowed to access port 27017 as clients"
     },
     "VpcId": {

--- a/cloudformation/mongo24.template
+++ b/cloudformation/mongo24.template
@@ -27,7 +27,7 @@
     "SSHAccessCIDR": {
       "Description": "IP address range allowed to SSH to the MongoDB instances",
       "Type": "String",
-      "Default": "10.0.0.0/8"
+      "Default": "10.249.0.0/16"
     },
     "ReplicationSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup::GroupName",


### PR DESCRIPTION
This change uses security groups rather than IP ranges for access to Mongo nodes, OpsManager and the OpsManager backup node.

The idea is to maintain a separate CloudFormation template with the actual security groups.
