### PR TITLE
Use keep-alive for snapshot download

### DIFF
--- a/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
+++ b/packer/resources/features/mongo-opsmanager/scripts/snapshot_backup.rb
@@ -112,7 +112,7 @@ def download_encrypt_backup(download_link)
   # download the file
   file_name=download_link.split('/')[-1] + '.gpg'
   gpg_command = generate_gpg_command(file_name)
-  download_encrypt_command = "curl #{download_link} | #{gpg_command}"
+  download_encrypt_command = "curl -H 'Connection: keep-alive' --compressed -v --keepalive-time 2 #{download_link} | #{gpg_command}"
   logger.info("Downloading and encrypting using command #{download_encrypt_command}.")
   `#{download_encrypt_command}`
   file_name


### PR DESCRIPTION
Over the past week I have seen intermittent errors when the backup cron job is downloading the snapshot from Ops Manager:

```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                               Dload  Upload   Total   Spent    Left  Speed
100  122M    0  122M    0     0  3691k      0 --:--:--  0:00:34 --:--:-- 4412k
curl: (18) transfer closed with outstanding read data remaining
```

I think part of the problem is that Ops Manager does not send a `Content-Length` header. According to [the following answer on Stackoverflow](http://stackoverflow.com/a/33550871/794003) it might help tuning the keep-alive settings when doing a large file transfer with cURL.

By explicitly setting a keep-alive header and setting a low keep-alive time (the time a connection needs to remain idle before sending keep-alive probes), the response from Ops Manager seems to honor keep-alive and and the transfer was more reliable:

```
> GET /backup/restore/v2/pull/backup.tar.gz HTTP/1.1
> User-Agent: curl/7.35.0
> Host: redacted:8081
> Accept: */*
> Accept-Encoding: deflate, gzip
> Connection: keep-alive
>
< HTTP/1.1 200 OK
< Content-Type: application/x-gzip
< Date: Thu, 04 Feb 2016 15:01:52 GMT
< transfer-encoding: chunked
< Connection: keep-alive
<
{ [data not shown]
100 2201M    0 2201M    0     0  8295k      0 --:--:--  0:04:31 --:--:-- 8920k
```

A [different route people are going down is forcing HTTP 1.0](http://stackoverflow.com/a/1848947/794003) (via `--http1.0`), but that did not help, apart from the error going away. The connection would terminate prematurely and most downloads yielded too small files.
