### PR TITLE
Add script for installing standalone MongoDB binaries

### DIFF
--- a/packer/resources/features/mongo24/scripts/install-binaries-only.sh
+++ b/packer/resources/features/mongo24/scripts/install-binaries-only.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-MONGO_DOWNLOAD_URL_BASE="http://downloads.mongodb.org/linux"
+S3_MIRROR_DOWNLOAD_URL_BASE="https://s3-eu-west-1.amazonaws.com/gu-mongodb-binary-mirror"
+INTERNET_MIRROR_DOWNLOAD_URL_BASE="https://fastdl.mongodb.org/linux"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -42,15 +43,37 @@ if [ -z "${MONGO_VERSION}" ]; then
     exit 1
 fi
 
-MONGO_DOWNLOAD_URL="${MONGO_DOWNLOAD_URL_BASE}/mongodb-linux-x86_64-${MONGO_VERSION}.tgz"
+function url_exists() {
+  local URL=${1}
+  curl --output /dev/null --silent --head --fail "${URL}"
+}
+
+function install_from_url() {
+  local DOWNLOAD_URL=${1}
+  local INSTALL_TARGET=${2}
+  local TEMPORARY_FILE="/tmp/mongodb.tar.gz.$$"
+
+  curl "${DOWNLOAD_URL}" --output "${TEMPORARY_FILE}"
+  mkdir -p "${INSTALL_TARGET}"
+  tar xzf "${TEMPORARY_FILE}" -C "${INSTALL_TARGET}" --strip-components 1
+  rm "${TEMPORARY_FILE}"
+}
+
+S3_MONGO_DOWNLOAD_URL="${S3_MIRROR_DOWNLOAD_URL_BASE}/mongodb-linux-x86_64-${MONGO_VERSION}.tgz"
+INTERNET_MONGO_DOWNLOAD_URL="${INTERNET_MIRROR_DOWNLOAD_URL_BASE}/mongodb-linux-x86_64-${MONGO_VERSION}.tgz"
+
 TEMPORARY_FILE="/tmp/mongodb-${MONGO_VERSION}.tar.gz.$$"
 INSTALL_TARGET="/opt/mongodb/${MONGO_VERSION}"
 
-if curl --output /dev/null --silent --head --fail "${MONGO_DOWNLOAD_URL}"; then
-  curl "${MONGO_DOWNLOAD_URL}" --output "${TEMPORARY_FILE}"
-  mkdir -p "${INSTALL_TARGET}"
-  tar xzf "${TEMPORARY_FILE}" -C "${INSTALL_TARGET}" --strip-components 1
+# Try installing from S3 first
+if url_exists "${S3_MONGO_DOWNLOAD_URL}" ; then
+  install_from_url "${S3_MONGO_DOWNLOAD_URL}" "${INSTALL_TARGET}"
 else
-  echo "URL does not exist: ${MONGO_DOWNLOAD_URL}"
-  exit 1
+  echo "Could not find MongoDB ${MONGO_VERSION} binaries in S3 mirror. Fetching from official MongoDB mirror."
+  if url_exists "${INTERNET_MONGO_DOWNLOAD_URL}"; then
+    install_from_url "${INTERNET_MONGO_DOWNLOAD_URL}" "${INSTALL_TARGET}"
+  else
+    echo "URL does not exist: ${INTERNET_MONGO_DOWNLOAD_URL}"
+    exit 1
+  fi
 fi

--- a/packer/resources/features/mongo24/scripts/install-binaries-only.sh
+++ b/packer/resources/features/mongo24/scripts/install-binaries-only.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -e
+
+MONGO_DOWNLOAD_URL_BASE="http://downloads.mongodb.org/linux"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function HELP {
+>&2 cat << EOF
+
+  Usage: ${0} -v version
+
+  This script downloads a specific version of the MongoDB binaries, but does
+  not install any services or configuration files.
+
+  This is useful when performing disaster recovery of a MongoDB cluster.
+
+    -v version    The MongoDB version to install the binaries for.
+
+    -h            Displays this help message. No further functions are
+                  performed.
+
+EOF
+exit 1
+}
+
+# Process options
+while getopts v:h FLAG; do
+  case $FLAG in
+    v)
+      MONGO_VERSION=$OPTARG
+    ;;
+    h)  #show help
+      HELP
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${MONGO_VERSION}" ]; then
+    echo "Must specify a MongoDB version"
+    exit 1
+fi
+
+MONGO_DOWNLOAD_URL="${MONGO_DOWNLOAD_URL_BASE}/mongodb-linux-x86_64-${MONGO_VERSION}.tgz"
+TEMPORARY_FILE="/tmp/mongodb-${MONGO_VERSION}.tar.gz.$$"
+INSTALL_TARGET="/opt/mongodb/${MONGO_VERSION}"
+
+if curl --output /dev/null --silent --head --fail "${MONGO_DOWNLOAD_URL}"; then
+  curl "${MONGO_DOWNLOAD_URL}" --output "${TEMPORARY_FILE}"
+  mkdir -p "${INSTALL_TARGET}"
+  tar xzf "${TEMPORARY_FILE}" -C "${INSTALL_TARGET}" --strip-components 1
+else
+  echo "URL does not exist: ${MONGO_DOWNLOAD_URL}"
+  exit 1
+fi


### PR DESCRIPTION
We've noticed during our disaster recovery simulations that a step that is stealing precious time getting back up and running is to get the MongoDB binaries in order to [reset the OpLog and setting up the cluster again](https://docs.opsmanager.mongodb.com/v1.8/tutorial/restore-replica-set/).

The way we've set up the fully Ops Manager orchestrated instances is that they download their binaries from Ops Manager, so by default there are no binaries available on the machine when they have just booted up.

This PR adds a small script `/opt/features/mongo24/scripts/install-binaries-only.sh` that downloads and unpacks the binaries for a specific MongoDB release.

Future usage might be to add the version(s) of MongoDB we know we need to the AMI so that they are readily available during a recovery situation.

```
# /opt/features/mongo24/scripts/install-binaries-only.sh -v 2.4.15
URL does not exist: http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.4.15.tgz


# /opt/features/mongo24/scripts/install-binaries-only.sh -v 2.4.14
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 90.9M  100 90.9M    0     0  45.8M      0  0:00:01  0:00:01 --:--:-- 45.8M

# ls -al /opt/mongodb
total 12
drwxr-xr-x 3 root root 4096 Feb  8 11:46 .
drwxr-xr-x 6 root root 4096 Feb  8 11:46 ..
drwxr-xr-x 3 root root 4096 Feb  8 11:46 2.4.14

 # ls -al /opt/mongodb/2.4.14/bin
 total 238104
 drwxr-xr-x 2 root root     4096 Feb  8 11:46 .
 drwxr-xr-x 3 root root     4096 Feb  8 11:46 ..
 -rwxr-xr-x 1  500  500 18336048 Apr 27  2015 bsondump
 -rwxr-xr-x 1  500  500  9556936 Apr 27  2015 mongo
 -rwxr-xr-x 1  500  500 18395656 Apr 27  2015 mongod
 -rwxr-xr-x 1  500  500 18393456 Apr 27  2015 mongodump
 -rwxr-xr-x 1  500  500 18348368 Apr 27  2015 mongoexport
 -rwxr-xr-x 1  500  500 18397504 Apr 27  2015 mongofiles
 -rwxr-xr-x 1  500  500 18360624 Apr 27  2015 mongoimport
 -rwxr-xr-x 1  500  500 18340112 Apr 27  2015 mongooplog
 -rwxr-xr-x 1  500  500 18340112 Apr 27  2015 mongoperf
 -rwxr-xr-x 1  500  500 18398320 Apr 27  2015 mongorestore
 -rwxr-xr-x 1  500  500 13888984 Apr 27  2015 mongos
 -rwxr-xr-x 1  500  500 18303144 Apr 27  2015 mongosniff
 -rwxr-xr-x 1  500  500 18385552 Apr 27  2015 mongostat
 -rwxr-xr-x 1  500  500 18340112 Apr 27  2015 mongotop
```
