### PR TITLE
Provide a tag that can be used for filtering in Riff-Raff

### DIFF
--- a/packer/default.json
+++ b/packer/default.json
@@ -27,6 +27,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "{{user `java7_image_name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "{{user `java7_image_name`}}",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",
@@ -48,6 +49,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "{{user `java8_image_name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "{{user `java8_image_name`}}",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",
@@ -69,6 +71,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "{{user `vivid_image_name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "{{user `vivid_image_name`}}",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",

--- a/packer/elk-stack.json
+++ b/packer/elk-stack.json
@@ -23,6 +23,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "elk-stack_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "elk-stack",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",

--- a/packer/kong.json
+++ b/packer/kong.json
@@ -23,6 +23,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "kong_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "kong",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",

--- a/packer/mongo24.json
+++ b/packer/mongo24.json
@@ -23,6 +23,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "mongo24_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "mongo24",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",
@@ -44,6 +45,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "mongo-opsmanager_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "mongo-opsmanager",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",
@@ -65,6 +67,7 @@
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
         "Name": "mongo-opsmanager-server_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "mongo-opsmanager-server",
         "BuildName": "{{user `build_name`}}",
         "Build":"{{user `build_number`}}",
         "Branch":"{{user `build_branch`}}",


### PR DESCRIPTION
It turns out that the tagging on AMIs from machine images is not enough to filter as desired from Riff-Raff. This fixes that by providing a ImageName in addition to Name where the former is a tag that doesn't contain the build ID or date stamp.

/cc @adamnfish 
