### PR TITLE
Make instance type for backup node configurable

### DIFF
--- a/cloudformation/mongo-opsmanager-backup.template
+++ b/cloudformation/mongo-opsmanager-backup.template
@@ -16,6 +16,16 @@
         "PROD"
       ]
     },
+    "InstanceType": {
+      "Description": "The instance type for the backup node(s) (typically smaller for prePROD)",
+      "Type": "String",
+      "AllowedValues": [
+        "m3.medium",
+        "m4.large",
+        "m4.xlarge",
+        "r3.xlarge"
+      ]
+    },
     "Stack": {
       "Description": "Stack name",
       "Type": "String"
@@ -449,7 +459,7 @@
             "Ref": "SSHSecurityGroup"
           }
         ],
-        "InstanceType": "m3.medium",
+        "InstanceType": {"Ref": "InstanceType"},
         "IamInstanceProfile": {
           "Ref": "ServerInstanceProfile"
         },


### PR DESCRIPTION
The backup node instance is quite a lot smaller than the PROD MongoDB nodes. This means indexes takes ages to build and it seems to be lagging behind at times.

This change makes the instance type configurable in the CloudFormation template.
