### PR TITLE
Use SSL for OpsManager backups and add Identity VPC

### DIFF
--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -427,7 +427,23 @@
             "FromPort": "443",
             "ToPort": "443",
             "CidrIp": "10.248.53.128/26"
-          }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": "10.248.153.0/26"
+          },{
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": "10.248.153.64/26"
+          },{
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": "10.248.153.128/26"
+          },
         ],
         "SecurityGroupEgress": [
           {

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -399,27 +399,33 @@
           {
             "IpProtocol": "tcp",
             "FromPort": "443",
+            "ToPort": "443",
             "CidrIp": "10.248.202.0/23"
           },{
             "IpProtocol": "tcp",
             "FromPort": "443",
+            "ToPort": "443",
             "CidrIp": "10.248.204.0/23"
           },{
             "IpProtocol": "tcp",
             "FromPort": "443",
+            "ToPort": "443",
             "CidrIp": "10.248.206.0/23"
           },
           {
             "IpProtocol": "tcp",
             "FromPort": "443",
+            "ToPort": "443",
             "CidrIp": "10.248.53.0/26"
           },{
             "IpProtocol": "tcp",
             "FromPort": "443",
+            "ToPort": "443",
             "CidrIp": "10.248.53.64/26"
           },{
             "IpProtocol": "tcp",
             "FromPort": "443",
+            "ToPort": "443",
             "CidrIp": "10.248.53.128/26"
           }
         ],

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -398,19 +398,29 @@
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
-            "FromPort": "8081",
-            "ToPort": "8081",
+            "FromPort": "443",
             "CidrIp": "10.248.202.0/23"
           },{
             "IpProtocol": "tcp",
-            "FromPort": "8081",
-            "ToPort": "8081",
+            "FromPort": "443",
             "CidrIp": "10.248.204.0/23"
           },{
             "IpProtocol": "tcp",
-            "FromPort": "8081",
-            "ToPort": "8081",
+            "FromPort": "443",
             "CidrIp": "10.248.206.0/23"
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "CidrIp": "10.248.53.0/26"
+          },{
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "CidrIp": "10.248.53.64/26"
+          },{
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "CidrIp": "10.248.53.128/26"
           }
         ],
         "SecurityGroupEgress": [
@@ -430,9 +440,10 @@
         "CrossZone": true,
         "Listeners": [
           {
-            "Protocol": "HTTP",
-            "LoadBalancerPort": "8081",
-            "InstancePort": "8081"
+            "Protocol": "HTTPS",
+            "LoadBalancerPort": "443",
+            "InstancePort": "8081",
+            "SSLCertificateId": { "Ref": "SSLCertificateArn" }
           }
         ],
         "HealthCheck": {

--- a/cloudformation/mongo-opsmanager-server.template
+++ b/cloudformation/mongo-opsmanager-server.template
@@ -308,7 +308,7 @@
           },
           {
             "IpProtocol": "tcp",
-            "FromPort": "8080",
+            "FromPort": "8081",
             "ToPort": "8081",
             "SourceSecurityGroupId": { "Ref": "BackupLoadBalancerSecurityGroup" }
           }
@@ -443,12 +443,12 @@
             "FromPort": "443",
             "ToPort": "443",
             "CidrIp": "10.248.153.128/26"
-          },
+          }
         ],
         "SecurityGroupEgress": [
           {
             "IpProtocol": "tcp",
-            "FromPort": "8080",
+            "FromPort": "8081",
             "ToPort": "8081",
             "CidrIp": "0.0.0.0/0"
           }


### PR DESCRIPTION
We'd like to use HTTPS for the Backup API as well (used for retrieving snapshots for restoration/pushing into S3).

Additionally, this PR also adds the relevant subnets we use, which previously wasn't in the CF template.
