### PR TITLE
Change source and version of packer binary

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 PACKER_DIR="${SCRIPTPATH}/packer_bin"
 
 PLATFORM=$(uname)
-PACKER_VERSION="0.8.2"
+PACKER_VERSION="0.8.6"
 
 if [ -x "${PACKER_DIR}/packer" ]; then
   if ${PACKER_DIR}/packer version | grep "Packer v${PACKER_VERSION}" >/dev/null 2>&1
@@ -21,10 +21,10 @@ fi
 
 case "$PLATFORM" in
   Darwin)
-    PACKER_URI="https://dl.bintray.com/mitchellh/packer/packer_${PACKER_VERSION}_darwin_amd64.zip"
+    PACKER_URI="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_darwin_amd64.zip"
     ;;
   Linux)
-    PACKER_URI="https://dl.bintray.com/mitchellh/packer/packer_${PACKER_VERSION}_linux_amd64.zip"
+    PACKER_URI="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"
     ;;
   *)
     echo "Unknown OS, please install packer yourself"


### PR DESCRIPTION
Hashicorp have changed the download location of the packer binaries. As such we need to update the setup script to use the new URLs.

At the same time I'm bumping the packer version to the latest release.

/cc @piuccio 
