### PR TITLE
Fix replication and reverse SG ownership for access

### DIFF
--- a/cloudformation/mongo-opsmanager-backup.template
+++ b/cloudformation/mongo-opsmanager-backup.template
@@ -80,6 +80,10 @@
       "Description": "Bucket to store team public keys in (used to encrypt backup)",
       "Type": "String",
       "Default": "flex-mongo-snapshots-backup-public-keys"
+    },
+    "MongoAccessSecurityGroup": {
+      "Description": "The security group from the Mongo CF stack which will allow access to the mongo instances",
+      "Type": "AWS::EC2::SecurityGroup::Id"
     }
   },
   "Conditions" : {
@@ -457,6 +461,9 @@
         "SecurityGroups": [
           {
             "Ref": "SSHSecurityGroup"
+          },
+          {
+            "Ref": "MongoAccessSecurityGroup"
           }
         ],
         "InstanceType": {"Ref": "InstanceType"},

--- a/cloudformation/mongo-opsmanager.template
+++ b/cloudformation/mongo-opsmanager.template
@@ -16,14 +16,6 @@
       "Type": "String",
       "Default": "10.249.0.0/16"
     },
-    "ReplicationSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup::Id",
-      "Description": "Security group allowed to access port 27017 for replication"
-    },
-    "ClientSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup::Id",
-      "Description": "Security group allowed to access port 27017 as clients"
-    },
     "DatabaseVolumeSize": {
       "Description": "Size of EBS volume for MongoDB data files (GB)",
       "Type": "Number",
@@ -96,6 +88,10 @@
         "m4.xlarge",
         "r3.xlarge"
       ]
+    },
+    "TemporaryAccessCIDR": {
+      "Description": "A CIDR block that can access the mongo instances (prior to adding the security group to the API / Backup). This should be removed after transition.",
+      "Type": "String"
     }
   },
   "Conditions" : {
@@ -383,6 +379,57 @@
         ]
       }
     },
+    "ReplicationSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow replication connections from other nodes in the replica set",
+        "VpcId": {
+          "Ref": "VpcId"
+        }
+      }
+    },
+    "ReplicationSecurityGroupIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": { "Fn::GetAtt": [ "ReplicationSecurityGroup", "GroupId" ] },
+        "IpProtocol": "tcp",
+        "FromPort": "27017",
+        "ToPort": "27017",
+        "SourceSecurityGroupId": { "Fn::GetAtt": [ "ReplicationSecurityGroup", "GroupId" ] }
+      }
+    },
+    "MongoAccessSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allows connections to the mongo replica set",
+        "VpcId": {
+          "Ref": "VpcId"
+        }
+      }
+    },
+    "AccessSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow connections to the replica set",
+        "VpcId": {
+          "Ref": "VpcId"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "27017",
+            "ToPort": "27017",
+            "CidrIp": {"Ref": "TemporaryAccessCIDR"}
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "27017",
+            "ToPort": "27017",
+            "SourceSecurityGroupId": { "Ref": "MongoAccessSecurityGroup"}
+          }
+        ]
+      }
+    },
     "AutoscalingGroup": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
@@ -459,7 +506,7 @@
             "Ref": "ReplicationSecurityGroup"
           },
           {
-            "Ref": "ClientSecurityGroup"
+            "Ref": "AccessSecurityGroup"
           }
         ],
         "InstanceType": { "Ref": "InstanceType" },
@@ -487,6 +534,12 @@
           }
         }
       }
+    }
+  },
+  "Outputs": {
+    "AccessSecurityGroup": {
+      "Description" : "The security group that instances should to access the mongo instances",
+      "Value" : {"Ref": "MongoAccessSecurityGroup"}
     }
   }
 }

--- a/cloudformation/mongo-opsmanager.template
+++ b/cloudformation/mongo-opsmanager.template
@@ -6,10 +6,9 @@
       "Description": "The EC2 Key Pair to allow SSH access to the instance",
       "Type": "AWS::EC2::KeyPair::KeyName"
     },
-    "SshKeyFileS3Url": {
-      "Description": "S3 URL for a list of public SSH keys to use for the default ubuntu user",
-      "Type": "String",
-      "Default": ""
+    "GitHubTeamName": {
+      "Description": "Name of GitHub team to install SSH keys for",
+      "Type": "String"
     },
     "SSHAccessCIDR": {
       "Description": "IP address range allowed to SSH to the MongoDB instances",
@@ -92,11 +91,6 @@
     "TemporaryAccessCIDR": {
       "Description": "A CIDR block that can access the mongo instances (prior to adding the security group to the API / Backup). This should be removed after transition.",
       "Type": "String"
-    }
-  },
-  "Conditions" : {
-    "DoNotRetrieveSshKeysFromS3" : {
-      "Fn::Equals" : [ {"Ref" : "SshKeyFileS3Url"}, "" ]
     }
   },
   "Resources": {
@@ -362,6 +356,27 @@
         ]
       }
     },
+    "GetTeamKeysPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "GetTeamKeysPolicy",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": ["s3:GetObject"],
+              "Resource": ["arn:aws:s3:::github-team-keys/*"]
+            },
+            {
+              "Effect":"Allow",
+              "Action": ["s3:ListBucket"],
+              "Resource":"arn:aws:s3:::github-team-keys"
+            }
+          ]
+        },
+        "Roles": [{"Ref": "ServerRole"}]
+      }
+    },
     "SSHSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -520,12 +535,7 @@
               [
                 "#!/bin/bash -ev",
 
-                { "Fn::If" : [
-                    "DoNotRetrieveSshKeysFromS3",
-                    "# Not retrieving SSH keys from S3",
-                    { "Fn::Join": [ "", ["/opt/features/ssh-keys/install.sh -k ", { "Ref": "SshKeyFileS3Url" }, " -u ubuntu", "\n" ]] }
-                  ]
-                },
+                { "Fn::Join": [ "", ["/opt/features/ssh-keys/initialise-keys-and-cron-job.sh -l -t ", { "Ref": "GitHubTeamName" }, " -b github-team-keys || true" ]] },
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", {"Ref":"DatabaseVolumeSize"}, " -d f -m /var/lib/mongodb -o 'defaults,noatime' -x ", {"Ref":"EBSOptions"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
 
                 "/opt/features/mongo-opsmanager/agent-configure.sh"

--- a/cloudformation/mongo-opsmanager.template
+++ b/cloudformation/mongo-opsmanager.template
@@ -17,8 +17,7 @@
     },
     "DatabaseVolumeSize": {
       "Description": "Size of EBS volume for MongoDB data files (GB)",
-      "Type": "Number",
-      "Default": "100"
+      "Type": "Number"
     },
     "DiskSpaceUtilisationAlertThreshold": {
       "Description": "Percentage of disk utilisation to trigger an alert for. E.g. 50 for alerting when any disk is at >= 50% capacity.",
@@ -77,7 +76,7 @@
     "EBSOptions": {
       "Description": "Extra parameters to add-encrypted script",
       "Type": "String",
-      "Default": "-t io1 -i 1000"
+      "Default": "-t gp2"
     },
     "InstanceType": {
       "Description": "The instance type for the database nodes (typically smaller for prePROD)",
@@ -236,7 +235,7 @@
               ],
               "Effect": "Allow",
               "Resource": { "Ref": "CustomerMasterKey"}
-            }
+              }
           ]
         },
         "Roles": [{"Ref": "ServerRole"}]
@@ -368,9 +367,9 @@
               "Resource": ["arn:aws:s3:::github-team-keys/*"]
             },
             {
-              "Effect":"Allow",
+              "Effect": "Allow",
               "Action": ["s3:ListBucket"],
-              "Resource":"arn:aws:s3:::github-team-keys"
+              "Resource": "arn:aws:s3:::github-team-keys"
             }
           ]
         },
@@ -397,10 +396,18 @@
     "ReplicationSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "Allow replication connections from other nodes in the replica set",
+        "GroupDescription": "Allow connections to mongo DB",
         "VpcId": {
           "Ref": "VpcId"
-        }
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "27017",
+            "ToPort": "27017",
+            "CidrIp": "10.0.0.0/8"
+          }
+        ]
       }
     },
     "ReplicationSecurityGroupIngress": {
@@ -548,7 +555,7 @@
   },
   "Outputs": {
     "AccessSecurityGroup": {
-      "Description" : "The security group that instances should to access the mongo instances",
+      "Description": "The security group that instances should to access the mongo instances",
       "Value" : {"Ref": "MongoAccessSecurityGroup"}
     }
   }


### PR DESCRIPTION
This PR improves the security groups in two ways:
- Introduce an explicit SG to allow each member of the replica set to talk to each other
- Create a security group for external services to add that will grant access to the Mongo cluster (this reverses the existing pattern of providing the security groups that should be granted access - and allows you to easily have 0-N users of the cluster)
