### PR TITLE
Fix the nginx access_log directive for Kong

### DIFF
--- a/packer/resources/features/kong/install.sh
+++ b/packer/resources/features/kong/install.sh
@@ -20,7 +20,7 @@ echo "Installing Kong"
 dpkg -i /tmp/kong.deb
 
 echo "Enabling nginx access logs"
-sed -i"" -e 's/access_log off/access_log on/' /etc/kong/kong.yml
+sed -i"" -e 's/access_log off;//' /etc/kong/kong.yml
 
 echo "Setting up logrotate for Kong"
 my_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Currently we are logging to a file called 'on', which is definitely not what I intended!
