### PR TITLE
Allow direct, internal access to elastic search

### DIFF
--- a/cloudformation/elk-stack.template
+++ b/cloudformation/elk-stack.template
@@ -263,6 +263,11 @@
                         "Protocol": "TCP",
                         "LoadBalancerPort": "6379",
                         "InstancePort": "6379"
+                    },
+                    {
+                        "Protocol": "TCP",
+                        "LoadBalancerPort": "80",
+                        "InstancePort": "80"
                     }
                 ],
                 "HealthCheck": {
@@ -439,6 +444,12 @@
                         "FromPort": "6379",
                         "ToPort": "6379",
                         "CidrIp": "0.0.0.0/0"
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "80",
+                        "ToPort": "80",
+                        "CidrIp": "10.249.0.0/16"
                     }
                 ],
                 "SecurityGroupEgress": [
@@ -447,6 +458,12 @@
                         "FromPort": "6379",
                         "ToPort": "6379",
                         "CidrIp": "0.0.0.0/0"
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "0",
+                        "ToPort": "65535",
+                        "CidrIp": "10.249.0.0/16"
                     }
                 ]
             }
@@ -462,6 +479,12 @@
                         "IpProtocol": "tcp",
                         "FromPort": "6379",
                         "ToPort": "6379",
+                        "SourceSecurityGroupId": { "Ref": "IntLBSG" }
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "80",
+                        "ToPort": "80",
                         "SourceSecurityGroupId": { "Ref": "IntLBSG" }
                     },
                     {

--- a/cloudformation/elk-stack.template
+++ b/cloudformation/elk-stack.template
@@ -97,6 +97,11 @@
         "MediaServiceAccountId": {
             "Description": "The AWS account ID for the Media Service",
             "Type": "String"
+        },
+        "InternalCidrIp": {
+            "Description": "What constitutes an 'internal' IP address (CIDR IP notation) and should therefore be allowed to access ElasticSearch directly",
+            "Type": "String",
+            "Default": "10.249.0.0/16"
         }
     },
 
@@ -437,7 +442,7 @@
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {
                 "VpcId": { "Ref": "VpcId" },
-                "GroupDescription": "Allow logstash messages to internal ELB",
+                "GroupDescription": "Allow logstash messages and http access to internal ELB",
                 "SecurityGroupIngress": [
                     {
                         "IpProtocol": "tcp",
@@ -449,7 +454,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "80",
                         "ToPort": "80",
-                        "CidrIp": "10.249.0.0/16"
+                        "CidrIp": { "Ref": "InternalCidrIp" }
                     }
                 ],
                 "SecurityGroupEgress": [
@@ -463,7 +468,7 @@
                         "IpProtocol": "tcp",
                         "FromPort": "0",
                         "ToPort": "65535",
-                        "CidrIp": "10.249.0.0/16"
+                        "CidrIp": { "Ref": "InternalCidrIp" }
                     }
                 ]
             }


### PR DESCRIPTION
To allow for logfile processing (e.g. migration monitoring).
