### PR TITLE
Remove oauth2-proxy bypass auth for elastic search

### DIFF
--- a/packer/resources/features/elk-stack/sysconfig-oauth2-proxy
+++ b/packer/resources/features/elk-stack/sysconfig-oauth2-proxy
@@ -10,4 +10,5 @@ OPTS="--client-id=@@CLIENT_ID \
         --email-domain=@@ALLOWED_DOMAIN \
         --http-address=0.0.0.0:4180 \
         --redirect-url=https://@@DOMAIN_NAME/oauth2/callback \
+        --skip-auth-regex='/__es/$' \
         --upstream=http://localhost:80/"

--- a/packer/resources/features/elk-stack/sysconfig-oauth2-proxy
+++ b/packer/resources/features/elk-stack/sysconfig-oauth2-proxy
@@ -10,5 +10,4 @@ OPTS="--client-id=@@CLIENT_ID \
         --email-domain=@@ALLOWED_DOMAIN \
         --http-address=0.0.0.0:4180 \
         --redirect-url=https://@@DOMAIN_NAME/oauth2/callback \
-        --skip-auth-regex='/__es/' \
         --upstream=http://localhost:80/"


### PR DESCRIPTION
This should be removed because it makes elasticsearch publicly available, without any authentication.

The External ELB forwards its `https` port directly to `oauth2-proxy` on instance port 4180, and the security group allows unrestricted access to this port externally (which is OK for just Kibana behind the oauth proxy but not for the unprotected ES port).

``` json
        "ExtLBSG": {
            "Type": "AWS::EC2::SecurityGroup",
            "Properties": {
                "SecurityGroupIngress": [
                    {
                        "IpProtocol": "tcp",
                        "FromPort": "443",
                        "ToPort": "443",
                        "CidrIp": "0.0.0.0/0"
                    }
                ],
```

...

``` json
        "ExtLB": {
            "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
            "Properties": {
                "Listeners": [
                    {
                        "Protocol": "HTTPS",
                        "LoadBalancerPort": "443",
                        "InstancePort": "4180",
                        "SSLCertificateId": { "Ref": "SSLCertificateId" }
                    }
```
