### PR TITLE
Adds path to the cron job to ensure aws commands can run.

### DIFF
--- a/packer/resources/features/ssh-keys/initialise-keys-and-cron-job.sh
+++ b/packer/resources/features/ssh-keys/initialise-keys-and-cron-job.sh
@@ -63,6 +63,9 @@ if [ ! -z "${INSTALL_FROM_LOCAL}" ]; then
 fi
 
 ${DIR}/install.sh -t ${GITHUB_TEAM_NAME} -b ${GITHUB_KEYS_BUCKET}
-echo "*/30 * * * * /opt/features/ssh-keys/install.sh -b ${GITHUB_KEYS_BUCKET} -t ${GITHUB_TEAM_NAME}" > ${DIR}/ssh-keys-cron-job.txt
+cat > ${DIR}/ssh-keys-cron-job.txt << EOF
+PATH=/bin:/usr/bin:/usr/local/bin
+*/30 * * * * /opt/features/ssh-keys/install.sh -b ${GITHUB_KEYS_BUCKET} -t ${GITHUB_TEAM_NAME} > ~${SSH_USER}/last-ssh-update.log 2>&1
+EOF
 echo "Initialising cron job"
 crontab -u ${SSH_USER} ${DIR}/ssh-keys-cron-job.txt


### PR DESCRIPTION
@sihil and I debugged why the cron job was not completing. It turns out it does not have access to run the AWS commands. The fix for this is to ensure the `PATH` is defined.  
Also logs output of task to a file.

We've run this on an instance and it works as expected.
cc/ @philmcmahon 
