### PR TITLE
Adds logrotation for the two opsmanager mongo replica sets

### DIFF
--- a/packer/resources/features/mongo-opsmanager/scripts/server_configure.rb
+++ b/packer/resources/features/mongo-opsmanager/scripts/server_configure.rb
@@ -36,6 +36,9 @@ def setup_mongod(options, name, port)
 
   mongo_config_template = ERB.new(File.read("#{options.template_dir}/mongod.conf.erb"))
   File.write("#{options.ch_root}/etc/mongod-#{@name}.conf", mongo_config_template.result)
+
+  mongo_logrotate_template = ERB.new(File.read("#{options.template_dir}/mongod.logrotate.erb"))
+  File.write("#{options.ch_root}/etc/logrotate.d/mongod-#{@name}", mongo_logrotate_template.result)
 end
 
 def setup_mms(options, data)

--- a/packer/resources/features/mongo-opsmanager/templates/mongod.conf.erb
+++ b/packer/resources/features/mongo-opsmanager/templates/mongod.conf.erb
@@ -5,71 +5,18 @@
 # Note: if you run mongodb as a non-root user (recommended) you may
 # need to create and set permissions for this directory manually,
 # e.g., if the parent directory isn't mutable by the mongodb user.
-dbpath=/var/lib/mongodb/<%= @name %>
+storage:
+  dbPath: "/var/lib/mongodb/<%= @name %>"
 
 #where to log
-logpath=/var/log/mongodb/mongod-<%= @name %>.log
+systemLog:
+  destination: file
+  path: "/var/log/mongodb/mongod-<%= @name %>.log"
+  logAppend: true
+  logRotate: reopen
 
-logappend=true
+net:
+  port: <%= @port %>
 
-port = <%= @port %>
-
-# Listen to local interface only. Comment out to listen on all interfaces.
-# bind_ip = 127.0.0.1
-
-# Disables write-ahead journaling
-# nojournal = true
-
-# Enables periodic logging of CPU utilization and I/O wait
-#cpu = true
-
-# Turn on/off security.  Off is currently the default
-#noauth = true
-#auth = true
-
-# Verbose logging output.
-#verbose = true
-
-# Inspect all client data for validity on receipt (useful for
-# developing drivers)
-#objcheck = true
-
-# Enable db quota management
-#quota = true
-
-# Set oplogging level where n is
-#   0=off (default)
-#   1=W
-#   2=R
-#   3=both
-#   7=W+some reads
-#diaglog = 0
-
-# Ignore query hints
-#nohints = true
-
-# Enable the HTTP interface (Defaults to port 28017).
-#httpinterface = true
-
-# Turns off server-side scripting.  This will result in greatly limited
-# functionality
-#noscripting = true
-
-# Turns off table scans.  Any query that would do a table scan fails.
-#notablescan = true
-
-# Disable data file preallocation.
-#noprealloc = true
-
-# Specify .ns file size for new databases.
-# nssize = <size>
-
-# Replication Options
-
-# in replicated mongo databases, specify the replica set name here
-replSet=<%= @name %>
-# maximum size in megabytes for replication operation log
-#oplogSize=1024
-# path to a key file storing authentication info for connections
-# between replica set members
-#keyFile=/path/to/keyfile
+replication:
+  replSetName: "<%= @name %>"

--- a/packer/resources/features/mongo-opsmanager/templates/mongod.logrotate.erb
+++ b/packer/resources/features/mongo-opsmanager/templates/mongod.logrotate.erb
@@ -1,0 +1,11 @@
+/var/log/mongodb/mongod-<%= @name %>.log {
+    daily
+    missingok
+    rotate 14
+    compress
+    postrotate
+        /bin/kill -SIGUSR1 `cat /var/run/mongodb-<%= @name %>.pid`
+    endscript
+    notifempty
+    nocreate
+}


### PR DESCRIPTION
This adds logrotation for the mongo logs under `/var/log/mongodb/`.

There are a couple of small pieces to this. Firstly the `logRotate: reopen` parameter  in the mongo configuration file that changes the behaviour of sending SIGUSR1 to the mongod process so it is compatible with logrotate (see https://docs.mongodb.org/v3.0/tutorial/rotate-log-files/). Unfortunately this parameter is only available in the new YAML format of the config file so we've had to change over.

Secondly there is the logrotate config file itself that causes the file to be moved and compressed and finally sends the rotate signal to the appropriate mongo process.
