### PR TITLE
Backup agent changes

### DIFF
--- a/cloudformation/mongo-opsmanager-backup.template
+++ b/cloudformation/mongo-opsmanager-backup.template
@@ -43,12 +43,12 @@
     "EBSOptions": {
       "Description": "Extra parameters to add-encrypted script",
       "Type": "String",
-      "Default": "-t io1 -i 1000"
+      "Default": "-t gp2"
     },
     "BackupVolumeSize": {
       "Description": "Size of EBS volume for backup files (GB)",
       "Type": "Number",
-      "Default": "100"
+      "Default": "300"
     },
     "VpcId": {
       "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",

--- a/packer/resources/features/mongo-opsmanager/agent-configure.sh
+++ b/packer/resources/features/mongo-opsmanager/agent-configure.sh
@@ -29,5 +29,8 @@ chown mongodb:mongodb /var/log/mongodb
 # chown the data mount
 chown mongodb /var/lib/mongodb
 
+# install memory/swap/disk usage monitoring agent
+${SCRIPTPATH}/../cloudwatch-monitoring/install.sh -d/,/var/lib/mongodb
+
 # Run the replica set initialisation script
 ${SCRIPTPATH}/scripts/opsmanager_add_self_to_replset.rb

--- a/packer/resources/features/mongo-opsmanager/agent-install.sh
+++ b/packer/resources/features/mongo-opsmanager/agent-install.sh
@@ -26,6 +26,3 @@ install -m 755 ${SCRIPTPATH}/templates/set-readahead /etc/init.d/set-readahead
 update-rc.d set-readahead defaults
 
 echo "net.ipv4.tcp_keepalive_time = 300" > /etc/sysctl.d/71-tcp-keepalive.conf
-
-# install memory/swap/disk usage monitoring agent
-${SCRIPTPATH}/../cloudwatch-monitoring/install.sh -d/,/var/lib/mongodb

--- a/packer/resources/features/mongo-opsmanager/backup-agent-configure.sh
+++ b/packer/resources/features/mongo-opsmanager/backup-agent-configure.sh
@@ -31,3 +31,6 @@ if ! getent passwd mongo-backup >/dev/null; then
 fi
 
 chown mongo-backup /backup
+
+# install memory/swap/disk usage monitoring agent
+${SCRIPTPATH}/../cloudwatch-monitoring/install.sh -d/,/backup


### PR DESCRIPTION
This changes the install and configure scripts to move the monitoring of /var/lib/mongodb so that it does not take place on the backup node.

This also changes the CF template to default to the `gp2` EBS volume type.
