### PR TITLE
Add alarming cron tab feature for back ups

### DIFF
--- a/cloudformation/mongo-opsmanager-backup.template
+++ b/cloudformation/mongo-opsmanager-backup.template
@@ -485,8 +485,7 @@
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", {"Ref":"BackupVolumeSize"}, " -d f -m /backup -o 'defaults,noatime' -x ", {"Ref":"EBSOptions"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
 
                 "/opt/features/mongo-opsmanager/backup-agent-configure.sh",
-                { "Fn::Join": [ "", ["echo '/opt/features/alarming-crontab/install.sh -u ubuntu -d 'Snapshot backup cron task' -c '*/30 * * * * /opt/features/mongo-opsmanager/scripts/snapshot_backup.rb -b ", {"Ref":"SnapshotBackupBucketName"}, " -k ", { "Ref": "SnapshotBackupPublicKeysBucketName" }, "'' > /opt/features/mongo-opsmanager/backup-agent-cron-job.txt"] ] },
-                "crontab -u mongo-backup /opt/features/mongo-opsmanager/backup-agent-cron-job.txt"
+                { "Fn::Join": [ "", ["/opt/features/alarming-crontab/install.sh -u ubuntu -d 'Snapshot backup cron task' -c '*/30 * * * * /opt/features/mongo-opsmanager/scripts/snapshot_backup.rb -b ", {"Ref":"SnapshotBackupBucketName"}, " -k ", { "Ref": "SnapshotBackupPublicKeysBucketName" }, "'"] ] }
               ]
             ]
           }

--- a/cloudformation/mongo-opsmanager-backup.template
+++ b/cloudformation/mongo-opsmanager-backup.template
@@ -80,6 +80,10 @@
       "Description": "Bucket to store team public keys in (used to encrypt backup)",
       "Type": "String",
       "Default": "flex-mongo-snapshots-backup-public-keys"
+    },
+    "PagerDutyServiceKey" : {
+      "Description": "A service key so that alarms can be sent if the backup job is not running",
+      "Type": "String"
     }
   },
   "Conditions" : {
@@ -470,6 +474,8 @@
               [
                 "#!/bin/bash -ev",
 
+                { "Fn::Join": [ "", ["/opt/features/pagerduty/install.sh -k ", {"Ref": "PagerDutyServiceKey"}] ]},
+
                 { "Fn::If" : [
                     "DoNotRetrieveSshKeysFromS3",
                     "# Not retrieving SSH keys from S3",
@@ -479,7 +485,7 @@
                 { "Fn::Join": [ "", ["/opt/features/ebs/add-encrypted.sh -s ", {"Ref":"BackupVolumeSize"}, " -d f -m /backup -o 'defaults,noatime' -x ", {"Ref":"EBSOptions"}, " -k ", { "Ref": "CustomerMasterKey" }] ] },
 
                 "/opt/features/mongo-opsmanager/backup-agent-configure.sh",
-                { "Fn::Join": [ "", ["echo '*/30 * * * * /opt/features/mongo-opsmanager/scripts/snapshot_backup.rb -b ", {"Ref":"SnapshotBackupBucketName"}, " -k ", { "Ref": "SnapshotBackupPublicKeysBucketName" }, "' > /opt/features/mongo-opsmanager/backup-agent-cron-job.txt"] ] },
+                { "Fn::Join": [ "", ["echo '/opt/features/alarming-crontab/install.sh -u ubuntu -d 'Snapshot backup cron task' -c '*/30 * * * * /opt/features/mongo-opsmanager/scripts/snapshot_backup.rb -b ", {"Ref":"SnapshotBackupBucketName"}, " -k ", { "Ref": "SnapshotBackupPublicKeysBucketName" }, "'' > /opt/features/mongo-opsmanager/backup-agent-cron-job.txt"] ] },
                 "crontab -u mongo-backup /opt/features/mongo-opsmanager/backup-agent-cron-job.txt"
               ]
             ]


### PR DESCRIPTION
Based on https://github.com/guardian/machine-images/pull/80 I have added the alarming crontab feature for mongo-opsmanager-backup. 

I'm not a 100% sure I've done this right - is the best way to test this to increase the autoscaling group and check or will this potentially cause multiple back ups?

Also we need to create a PagerDuty service key.

cc @nlindblad @sihil 
