### PR TITLE
add browser testing ami

### DIFF
--- a/packer/browser-testing.json
+++ b/packer/browser-testing.json
@@ -1,0 +1,61 @@
+{
+  "variables": {
+    "build_number": "DEV",
+    "build_name": null,
+    "build_vcs_ref": "",
+    "account_numbers": "",
+    "build_branch": "DEV",
+    "euw1_source_ami": "ami-b6b73dc5",
+    "instance_profile": "PackerUser-PackerInstanceProfile-O1WXS2KZ0LV1",
+    "vpc_id": "",
+    "subnet_id": ""
+  },
+  "builders": [
+    {
+      "name": "browser-testing",
+      "type": "amazon-ebs",
+      "region": "eu-west-1",
+      "source_ami": "{{user `euw1_source_ami`}}",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "vpc_id": "{{user `vpc_id`}}",
+      "subnet_id": "{{user `subnet_id`}}",
+      "run_tags": {"Stage":"INFRA", "Stack":"packer", "App": "{{user `build_name`}}"},
+      "ami_name": "browser-testing_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+      "ami_description": "AMI for browser-testing built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
+      "ami_users": "{{user `account_numbers`}}",
+      "tags": {
+        "Name": "browser-testing_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "browser-testing",
+        "BuildName": "{{user `build_name`}}",
+        "Build":"{{user `build_number`}}",
+        "Branch":"{{user `build_branch`}}",
+        "VCSRef":"{{user `build_vcs_ref`}}",
+        "SourceAMI":"{{user `euw1_source_ami`}}"
+      }
+    }
+  ],
+
+  "provisioners" : [
+    {
+      "type": "file",
+      "source": "resources/features",
+      "destination": "/tmp"
+    },
+    {
+      "type": "shell",
+      "script": "resources/ubuntu-wily.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
+    },
+    {
+      "type": "shell",
+      "script": "resources/install-java8.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
+    },
+    {
+      "type": "shell",
+      "script": "resources/features/browser-testing/install.sh",
+      "execute_command": "{{ .Vars }} sudo -E bash -x '{{ .Path }}'"
+    }
+  ]
+}

--- a/packer/resources/features/browser-testing/README.MD
+++ b/packer/resources/features/browser-testing/README.MD
@@ -1,0 +1,9 @@
+# Browser UI testing
+
+This feature installs Google Chrome, Chromedriver and the virtual frame buffer, Xvfb, to allow for headless browser testing on fully featured Chrome.
+
+The install script does the following:
+ - Installs Xvfb
+ - Installs the latest version of Google Chrome and associated packages
+ - Installs Chromedriver 2.21
+ - Creates and enables an Xvfb service

--- a/packer/resources/features/browser-testing/install.sh
+++ b/packer/resources/features/browser-testing/install.sh
@@ -3,8 +3,6 @@
 
 set +e
 
-echo "Environment=DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /lib/systemd/system/dbus.service
-
 echo "Install & setup Xvfb"
 apt-get install -y xvfb
 

--- a/packer/resources/features/browser-testing/install.sh
+++ b/packer/resources/features/browser-testing/install.sh
@@ -3,7 +3,7 @@
 
 set +e
 
-echo "DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /etc/environment
+echo "Environment=DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /lib/systemd/system/dbus.service
 
 echo "Install & setup Xvfb"
 apt-get install -y xvfb

--- a/packer/resources/features/browser-testing/install.sh
+++ b/packer/resources/features/browser-testing/install.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+#run as sudo
+
+set +e
+
+echo "DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /etc/environment
+
+echo "Install & setup Xvfb"
+apt-get install -y xvfb
+
+echo "Install & setup Chrome"
+wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -O /tmp/google-chrome-stable_current_amd64.deb
+dpkg -i /tmp/google-chrome-stable_current_amd64.deb
+apt-get install -f -y
+
+echo "Install Chromedriver 2.21"
+wget -q -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/2.21/chromedriver_linux64.zip && unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/;
+chmod 751 /usr/local/bin/chromedriver
+
+echo "Add Xvfb as service & run"
+cat <<EOF > /etc/systemd/system/xvfb.service
+[Unit]
+Description=X Virtual Frame Buffer Service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/Xvfb :1 -screen 0 1024x768x24
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable /etc/systemd/system/xvfb.service


### PR DESCRIPTION
creates an ami for use with https://github.com/guardian/editorial-tools-production-monitoring
