### PR TITLE
Add BuiltBy tag to AMIs

### DIFF
--- a/packer/browser-testing.json
+++ b/packer/browser-testing.json
@@ -25,6 +25,7 @@
       "ami_description": "AMI for browser-testing built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
       "ami_users": "{{user `account_numbers`}}",
       "tags": {
+        "BuiltBy":"machine-images",
         "Name": "browser-testing_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "ImageName": "browser-testing",
         "BuildName": "{{user `build_name`}}",

--- a/packer/default.json
+++ b/packer/default.json
@@ -30,6 +30,7 @@
       "ami_users": "{{user `account_numbers`}}",
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
+        "BuiltBy": "machine-images",
         "Name": "{{user `java7_image_name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "ImageName": "{{user `java7_image_name`}}",
         "BuildName": "{{user `build_name`}}",
@@ -54,6 +55,7 @@
       "ami_users": "{{user `account_numbers`}}",
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
+        "BuiltBy": "machine-images",
         "Name": "{{user `java8_image_name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "ImageName": "{{user `java8_image_name`}}",
         "BuildName": "{{user `build_name`}}",
@@ -78,6 +80,7 @@
       "ami_users": "{{user `account_numbers`}}",
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
+        "BuiltBy": "machine-images",
         "Name": "{{user `wily_image_name`}}_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "ImageName": "{{user `wily_image_name`}}",
         "BuildName": "{{user `build_name`}}",

--- a/packer/elk-stack.json
+++ b/packer/elk-stack.json
@@ -26,6 +26,7 @@
       "ami_users": "{{user `account_numbers`}}",
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
+        "BuiltBy": "machine-images",
         "Name": "elk-stack_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "ImageName": "elk-stack",
         "BuildName": "{{user `build_name`}}",

--- a/packer/kong.json
+++ b/packer/kong.json
@@ -26,6 +26,7 @@
       "ami_users": "{{user `account_numbers`}}",
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
+        "BuiltBy": "machine-images",
         "Name": "kong_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "ImageName": "kong",
         "BuildName": "{{user `build_name`}}",

--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -26,6 +26,7 @@
       "ami_users": "{{user `account_numbers`}}",
       "iam_instance_profile": "{{user `instance_profile`}}",
       "tags": {
+        "BuiltBy": "machine-images",
         "Name": "mongo24_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
         "ImageName": "mongo24",
         "BuildName": "{{user `build_name`}}",


### PR DESCRIPTION
Following the [convention adopted in amigo](https://github.com/guardian/amigo/pull/33). This will allow amiable to more accurately determine which images have been built by `machine-images`.
