### PR TITLE
upgrades kibana & es version

### DIFF
--- a/packer/resources/features/elk-stack/elasticsearch.yml
+++ b/packer/resources/features/elk-stack/elasticsearch.yml
@@ -202,12 +202,12 @@ bootstrap.mlockall: true
 
 # Set the bind address specifically (IPv4 or IPv6):
 #
-# network.bind_host: 192.168.0.1
+network.bind_host: 0.0.0.0
 
 # Set the address other nodes will use to communicate with this node. If not
 # set, it is automatically derived. It must point to an actual IP address.
 #
-# network.publish_host: 192.168.0.1
+network.publish_host: _ec2:privateIp_
 
 # Set both 'bind_host' and 'publish_host':
 #
@@ -232,9 +232,6 @@ bootstrap.mlockall: true
 # Disable HTTP completely:
 #
 # http.enabled: false
-
-http.host: 127.0.0.1
-
 
 ################################### Gateway ###################################
 
@@ -345,7 +342,7 @@ discovery.type: ec2
 discovery.ec2.tag.Stack: "@@STACK"
 discovery.ec2.tag.App: "@@APP"
 
-cloud.aws.region: @@REGION
+cloud.aws.region: "@@REGION"
 
 # GCE discovery allows to use Google Compute Engine API in order to perform discovery.
 #
@@ -395,3 +392,5 @@ action.disable_delete_all_indices: true
 
 ## Add breaker settings (to prevent out of memory errors)
 indices.breaker.fielddata.limit: 40%
+
+cloud.node.auto_attributes: true

--- a/packer/resources/features/elk-stack/elasticsearch.yml
+++ b/packer/resources/features/elk-stack/elasticsearch.yml
@@ -393,7 +393,5 @@ cloud.aws.region: @@REGION
 action.auto_create_index: true
 action.disable_delete_all_indices: true
 
-script.disable_dynamic: true
-
 ## Add breaker settings (to prevent out of memory errors)
 indices.breaker.fielddata.limit: 40%

--- a/packer/resources/features/elk-stack/install.sh
+++ b/packer/resources/features/elk-stack/install.sh
@@ -65,6 +65,7 @@ mv /opt/kibana-${KIBANA_VERSION}-linux-x64 /opt/kibana
 
 useradd -M -r -U -s /bin/false -d /opt/kibana kibana
 mkdir /var/log/kibana
+chown -R kibana:kibana /opt/kibana
 chown kibana:kibana /var/log/kibana
 cp $FEATURE_ROOT/systemd-kibana.service /etc/systemd/system/kibana.service
 

--- a/packer/resources/features/elk-stack/install.sh
+++ b/packer/resources/features/elk-stack/install.sh
@@ -11,7 +11,7 @@ KIBANA_VERSION=4.5.1
 
 ## Add repositories we are going to use
 wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-echo "deb http://packages.elastic.co/elasticsearch/2.3/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+echo "deb https://packages.elastic.co/elasticsearch/2.x/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 echo "deb http://packages.elastic.co/logstash/1.5/debian stable main" > /etc/apt/sources.list.d/logstash.list
 
 ## Update index and install packages

--- a/packer/resources/features/elk-stack/install.sh
+++ b/packer/resources/features/elk-stack/install.sh
@@ -7,11 +7,11 @@ set -e
 
 FEATURE_ROOT=/opt/features/elk-stack
 
-KIBANA_VERSION=4.1.1
+KIBANA_VERSION=4.5.1
 
 ## Add repositories we are going to use
 wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-echo "deb http://packages.elastic.co/elasticsearch/1.7/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
+echo "deb http://packages.elastic.co/elasticsearch/2.3/debian stable main" > /etc/apt/sources.list.d/elasticsearch.list
 echo "deb http://packages.elastic.co/logstash/1.5/debian stable main" > /etc/apt/sources.list.d/logstash.list
 
 ## Update index and install packages
@@ -31,11 +31,10 @@ crontab -u root - << EOM
 EOM
 
 ## Install Elasticsearch plugins
-/usr/share/elasticsearch/bin/plugin --install elasticsearch/elasticsearch-cloud-aws/2.7.0
-/usr/share/elasticsearch/bin/plugin --install mobz/elasticsearch-head
-/usr/share/elasticsearch/bin/plugin --install lukas-vlcek/bigdesk
-/usr/share/elasticsearch/bin/plugin --install karmi/elasticsearch-paramedic
-/usr/share/elasticsearch/bin/plugin --install royrusso/elasticsearch-HQ
+/usr/share/elasticsearch/bin/plugin install cloud-aws
+/usr/share/elasticsearch/bin/plugin install mobz/elasticsearch-head
+/usr/share/elasticsearch/bin/plugin install karmi/elasticsearch-paramedic
+/usr/share/elasticsearch/bin/plugin install royrusso/elasticsearch-HQ
 
 ## Install the curator
 pip install elasticsearch-curator


### PR DESCRIPTION
This was motivated by wanting to use the ✨improved✨ dashboard features in newer versions of Kibana, [4.5](https://www.elastic.co/blog/kibana-4-5-0-released), e.g. Assign labels to metric aggregations

This requires ES 2.3 so this is being upgraded too.
