### PR TITLE
Add SG parameter for Vulnerability Scanning

### DIFF
--- a/cloudformation/mongo24.template
+++ b/cloudformation/mongo24.template
@@ -37,6 +37,10 @@
       "Type": "AWS::EC2::SecurityGroup::Id",
       "Description": "Security group allowed to access port 27017 as clients"
     },
+    "VulnerabilityScanningSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup::Id",
+      "Description": "Security group that grants access to the account's Vulnerability Scanner"
+    },
     "VpcId": {
       "Description": "ID of the VPC onto which to launch the application eg. vpc-1234abcd",
       "Type": "AWS::EC2::VPC::Id"
@@ -471,6 +475,9 @@
           },
           {
             "Ref": "ClientSecurityGroup"
+          },
+          {
+            "Ref": "VulnerabilityScanningSecurityGroup"
           }
         ],
         "InstanceType": { "Ref": "InstanceType" },


### PR DESCRIPTION
There is now a vulnerability scanner in the Identity account. This PR lets us add a Security Group to instances to allow vulnerability scans.

The usefulness of this PR will depend to some extent on how widely used this is, since not all accounts have a scanner. Anyone that uses this or has an opinion, feel free to weigh in?
