### PR TITLE
Mongo 2.6.12 ami

### DIFF
--- a/packer/mongo.json
+++ b/packer/mongo.json
@@ -36,6 +36,30 @@
       }
     },
     {
+      "name": "mongo26",
+      "type": "amazon-ebs",
+      "region": "eu-west-1",
+      "source_ami": "{{user `euw1_source_ami`}}",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "vpc_id": "{{user `vpc_id`}}",
+      "subnet_id": "{{user `subnet_id`}}",
+      "run_tags": {"Stage":"INFRA", "Stack":"packer", "App": "{{user `build_name`}}"},
+      "ami_name": "mongo26_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+      "ami_description": "AMI for mongo26 built by TeamCity: {{user `build_name`}}#{{user `build_number`}}",
+      "ami_users": "{{user `account_numbers`}}",
+      "iam_instance_profile": "{{user `instance_profile`}}",
+      "tags": {
+        "Name": "mongo26_{{user `build_number`}}_{{isotime \"2006/01/02_15-04-05\"}}",
+        "ImageName": "mongo26",
+        "BuildName": "{{user `build_name`}}",
+        "Build":"{{user `build_number`}}",
+        "Branch":"{{user `build_branch`}}",
+        "VCSRef":"{{user `build_vcs_ref`}}",
+        "SourceAMI":"{{user `euw1_source_ami`}}"
+      }
+    },
+    {
       "name": "mongo-opsmanager",
       "type": "amazon-ebs",
       "region": "eu-west-1",
@@ -103,6 +127,14 @@
         "/usr/bin/sudo -E /bin/bash -x /opt/features/mongo24/install.sh"
       ],
       "only": ["mongo24"]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "/bin/sleep 2",
+        "/usr/bin/sudo -E /bin/bash -x /opt/features/mongo26/install.sh"
+      ],
+      "only": ["mongo26"]
     },
     {
       "type": "shell",

--- a/packer/resources/features/mongo26/README.md
+++ b/packer/resources/features/mongo26/README.md
@@ -1,0 +1,10 @@
+MongoDB 2.6 Server
+==================
+
+This feature is initially designed to be used for the Flexible Content secondary database. 
+It is designed to work on pre-systemd based versions of Ubuntu (i.e. Trusty).
+
+The install script:
+ - installs the relevant package
+ - installs ruby gems required by the configuration scripts
+ - sets up logging for the configuration scripts

--- a/packer/resources/features/mongo26/configure.sh
+++ b/packer/resources/features/mongo26/configure.sh
@@ -92,10 +92,19 @@ if [ -z "${DATABASE_NAME}"  -o -z  "${DATABASE_USER}" -o -z "${DATABASE_PWD}" -o
     exit 1
 fi
 
+# Install the config file to /etc/mongod.conf
+CONFIG_FILE=/etc/mongod.conf
+cp ${CONFIG_FILE} ${CONFIG_FILE}.original
+install -m 644 -o root -g root ${SCRIPTPATH}/mongod.conf ${CONFIG_FILE}
+
 # chown the data and log
 chown mongodb /var/lib/mongodb
 chown mongodb:mongodb /var/log/mongodb
 
+# Restart mongod
+service mongod restart
+
+sleep 5
 
 mongo <<EOF
 use admin

--- a/packer/resources/features/mongo26/initialise-database.sh
+++ b/packer/resources/features/mongo26/initialise-database.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function HELP {
+>&2 cat << EOF
+
+  Usage: ${0} -f properties-file [-u ubuntu]
+
+  This script will create a database and add a user and password
+
+    -u user       [optional] the user to install the SSH keys for. Defaults to ubuntu.
+
+    -f properties-file The file where the database and user credentials are stored
+
+    -h            Displays this help message. No further functions are
+                  performed.
+
+EOF
+exit 1
+}
+
+# Process options
+while getopts u:f:h FLAG; do
+  case $FLAG in
+    u)
+      SSH_USER=$OPTARG
+      ;;
+    f)
+      FILE_NAME=$OPTARG
+      ;;
+    h)  #show help
+      HELP
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${FILE_NAME}" ]; then
+    echo "Must specify the file (-f) to fetch database name and credentials"
+    exit 1
+fi
+
+if [ -z "${SSH_USER}" ]; then
+  SSH_USER="ubuntu"
+fi
+
+DATABASE_NAME=
+DATABASE_USER=
+DATABASE_PWD=
+
+# read file line by line and populate the array
+while IFS='=' read -r k v; do
+   if [ "$k" == "mongo.database.name" ]
+   then
+    DATABASE_NAME=$v
+   fi
+   if [ "$k" == "mongo.database.username" ]
+   then
+    DATABASE_USER=$v
+   fi
+   if [ "$k" == "mongo.database.password" ]
+   then
+    DATABASE_PWD=$v
+   fi
+
+done < $FILE_NAME
+
+echo $DATABASE_NAME
+echo $DATABASE_USER
+echo $DATABASE_PWD
+
+if [ -z "${DATABASE_NAME}"  -o -z  "${DATABASE_USER}" -o -z "${DATABASE_PWD}" ]; then
+    echo "One or more of database name, user and password is missing. Exiting."
+    exit 1
+fi
+
+mongo <<EOF
+use $DATABASE_NAME
+db.createUser({user: "$DATABASE_USER", pwd: "$DATABASE_PWD", roles: ["readWrite"]});
+EOF
+
+echo "Done"
+exit

--- a/packer/resources/features/mongo26/initialise-database.sh
+++ b/packer/resources/features/mongo26/initialise-database.sh
@@ -85,7 +85,6 @@ while IFS='=' read -r k v; do
    then
     ADMIN_PWD=$v
    fi
-
 done < $PROPERTIES_FILE
 
 if [ -z "${DATABASE_NAME}"  -o -z  "${DATABASE_USER}" -o -z "${DATABASE_PWD}" -o -z "${ADMIN_USER}" -o -z "${ADMIN_PWD}"]; then
@@ -101,6 +100,8 @@ chown mongodb:mongodb /var/log/mongodb
 mongo <<EOF
 use admin
 db.createUser({ user: "$ADMIN_USER", pwd: "$ADMIN_PWD", roles: ["userAdminAnyDatabase"] })
+db.auth("$ADMIN_USER", "$ADMIN_PWD")
+db.runCommand({authSchemaUpgrade: 1 });
 use $DATABASE_NAME
 db.createUser({user: "$DATABASE_USER", pwd: "$DATABASE_PWD", roles: ["readWrite"]});
 EOF

--- a/packer/resources/features/mongo26/install.sh
+++ b/packer/resources/features/mongo26/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Install MongoDB 2.6
+
+SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' > /etc/apt/sources.list.d/mongodb.list
+apt-get update
+apt-get install -y mongodb-10gen=2.6.12 ruby ruby-dev sysfsutils
+
+#cp ${SCRIPTPATH}/mongodb.service /etc/systemd/system/mongodb.service
+
+#service mongodb restart
+
+# TODO: replace with bundler
+echo "Installing Ruby gems for helper scripts"
+gem install aws-sdk -v '~> 2'
+gem install mongo -v '~> 2'
+gem install bson -v '~> 3'
+
+echo "Installing rsyslog config"
+cat > /etc/rsyslog.d/31-mongo-scripts.conf <<EOF
+local1.*    /var/log/mongodb/scripts.log
+EOF
+service rsyslog restart
+
+# install script to disable transparent huge pages
+install -m 755 ${SCRIPTPATH}/../mongo-opsmanager/templates/disable-transparent-hugepages /etc/init.d/disable-transparent-hugepages
+update-rc.d disable-transparent-hugepages defaults
+
+# install script to set readahead
+install -m 755 ${SCRIPTPATH}/../mongo-opsmanager/templates/set-readahead /etc/init.d/set-readahead
+update-rc.d set-readahead defaults
+
+echo "net.ipv4.tcp_keepalive_time = 300" > /etc/sysctl.d/71-tcp-keepalive.conf
+
+# install memory/swap/disk usage monitoring agent
+${SCRIPTPATH}/../cloudwatch-monitoring/install.sh -d/,/var/lib/mongodb

--- a/packer/resources/features/mongo26/install.sh
+++ b/packer/resources/features/mongo26/install.sh
@@ -8,7 +8,7 @@ SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' > /etc/apt/sources.list.d/mongodb.list
 apt-get update
-apt-get install -y mongodb-10gen=2.6.12 ruby ruby-dev sysfsutils
+apt-get install -y mongodb-org=2.6.12 ruby ruby-dev sysfsutils
 
 #cp ${SCRIPTPATH}/mongodb.service /etc/systemd/system/mongodb.service
 

--- a/packer/resources/features/mongo26/mongod.conf
+++ b/packer/resources/features/mongo26/mongod.conf
@@ -1,0 +1,10 @@
+# mongod.conf
+
+#Generated in machine-images
+dbpath=/var/lib/mongodb
+
+logpath=/var/log/mongodb/mongod.log
+
+logappend=true
+
+auth = true


### PR DESCRIPTION
Added an AMI with 2.6.12 Mongo.

I've also created a script to help initialise the database and user credentials. This relies on a file being passed which must contain the following properties. 

```
mongo.database.name=
mongo.database.username=
mongo.database.password=
```

cc @philmcmahon @sihil 
