### PR TITLE
Update to Mongo 2.4.14

### DIFF
--- a/packer/resources/features/mongo24/install.sh
+++ b/packer/resources/features/mongo24/install.sh
@@ -8,7 +8,7 @@ SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' > /etc/apt/sources.list.d/mongodb.list
 apt-get update
-apt-get install -y mongodb-10gen=2.4.9 ruby ruby-dev sysfsutils
+apt-get install -y mongodb-10gen=2.4.14 ruby ruby-dev sysfsutils
 
 #cp ${SCRIPTPATH}/mongodb.service /etc/systemd/system/mongodb.service
 


### PR DESCRIPTION
Use latest mongo version to prevent Ops Manager update.

@jfsoul 