### PR TITLE
Allow r4 instance type in cloudformation for mongo24

### DIFF
--- a/cloudformation/mongo24.template
+++ b/cloudformation/mongo24.template
@@ -98,7 +98,8 @@
       "AllowedValues": [
         "m4.large",
         "m4.xlarge",
-        "r3.xlarge"
+        "r3.xlarge",
+        "r4.xlarge"
       ]
     },
     "MemberVisibilityMask": {


### PR DESCRIPTION
cc: @markjamesbutler 